### PR TITLE
Improve logging/checks around node IDs

### DIFF
--- a/libs/http-datasource/src/datasource-client.cpp
+++ b/libs/http-datasource/src/datasource-client.cpp
@@ -16,6 +16,13 @@ RemoteDataSource::RemoteDataSource(const std::string& host, uint16_t port)
         throw logRuntimeError("Failed to fetch datasource info.");
     info_ = DataSourceInfo::fromJson(nlohmann::json::parse(fetchedInfoJson->body));
 
+    if (info_.nodeId_.empty()) {
+        // Unique node IDs are required for the field offsets.
+        throw logRuntimeError(
+            stx::format("Remote data source is missing node ID! Source info: {}",
+                fetchedInfoJson->body));
+    }
+
     // Create as many clients as parallel requests are allowed.
     for (auto i = 0; i < std::max(info_.maxParallelJobs_, 1); ++i)
         httpClients_.emplace_back(host, port);

--- a/libs/http-service/src/cli.cpp
+++ b/libs/http-service/src/cli.cpp
@@ -171,6 +171,11 @@ struct FetchCommand
                 }
             });
         cli.request(request)->wait();
+
+        if (request->getStatus() == NoDataSource)
+            throw logRuntimeError("Failed to fetch sources: no matching data source.");
+        if (request->getStatus() == Aborted)
+            throw logRuntimeError("Failed to fetch sources: request aborted.");
     }
 };
 

--- a/libs/http-service/src/http-client.cpp
+++ b/libs/http-service/src/http-client.cpp
@@ -16,7 +16,8 @@ struct HttpClient::Impl {
         client_.set_keep_alive(false);
         auto sourcesJson = client_.Get("/sources");
         if (!sourcesJson || sourcesJson->status != 200)
-            throw logRuntimeError("Failed to fetch sources.");
+            throw logRuntimeError(
+                stx::format("Failed to fetch sources: [{}]", sourcesJson->status));
         for (auto const& info : nlohmann::json::parse(sourcesJson->body)) {
             auto parsedInfo = DataSourceInfo::fromJson(info);
             sources_.emplace(parsedInfo.mapId_, parsedInfo);

--- a/libs/service/src/cache.cpp
+++ b/libs/service/src/cache.cpp
@@ -107,10 +107,15 @@ void Cache::putTileFeatureLayer(TileFeatureLayer::Ptr const& l)
 
 simfil::FieldId Cache::cachedFieldsOffset(std::string const& nodeId)
 {
+    if (nodeId.empty()) {
+        throw logRuntimeError("Tried to query cached fields offset for empty node ID!");
+    }
     std::unique_lock fieldsOffsetLock(fieldCacheOffsetMutex_);
     auto it = fieldCacheOffsets_.find(nodeId);
-    if (it != fieldCacheOffsets_.end())
+    if (it != fieldCacheOffsets_.end()) {
+        log().trace("Cached fields offset for {}: {}", nodeId, it->second);
         return it->second;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Adds sanity checks that would have caught the bug in [MAPV-113](https://youtrack.nds-association.org/issue/MAPV-113/Properties-are-parsed-incorrectly-when-mapget-is-connected-to-different-data-sources).

**Testing**

Set up multiple data sources (live or geoJSON, e.g. islands 5 and 6) using the stand before MAPV-113 fix. mapget should throw an error since multiple data sources are registering with the same (empty) node ID.