### PR TITLE
http-datasource: Disable child proc timeout for dbg

### DIFF
--- a/libs/http-datasource/src/datasource-client.cpp
+++ b/libs/http-datasource/src/datasource-client.cpp
@@ -113,11 +113,15 @@ RemoteDataSourceProcess::RemoteDataSourceProcess(std::string const& commandLine)
         true);
 
     std::unique_lock<std::mutex> lock(mutex_);
+#if defined(NDEBUG)
     if (!cv_.wait_for(lock, std::chrono::seconds(10), [this] { return remoteSource_ != nullptr; }))
     {
         throw logRuntimeError(
             "Timeout waiting for the child process to initialize the remote data source.");
     }
+#else
+    cv_.wait(lock, [this] { return remoteSource_ != nullptr; });
+#endif
 }
 
 RemoteDataSourceProcess::~RemoteDataSourceProcess()


### PR DESCRIPTION
Disable child process timeout in debug builds. Running mapget in a profiler (e.G. valgrind) can cause a major slowdown, which leads to the timeout to always trigger. Another option would be to make the timeout configurable either via a cmd-line option from the front-end or via an environment variable.