### PR TITLE
Add Attribute::setValidity

### DIFF
--- a/libs/model/include/mapget/model/attr.h
+++ b/libs/model/include/mapget/model/attr.h
@@ -7,7 +7,7 @@ namespace mapget
 
 /**
  * Represents a feature attribute which belongs to an
- * AttributeLayer, and may have typed `direction` and some
+ * AttributeLayer, and may have typed `direction` and
  * `validity` fields in addition to other arbitrary object fields.
  */
 class Attribute : public simfil::ProceduralObject<2, Attribute>
@@ -33,9 +33,11 @@ public:
     void setDirection(Direction const& v);
 
     /**
-     * Attribute validity accessor.
+     * Attribute validity accessors.
      */
-    model_ptr<Geometry> validity();
+    bool hasValidity() const;
+    model_ptr<Geometry> validity() const;
+    void setValidity(model_ptr<Geometry> const& validityGeom);
 
     /**
      * Read-only attribute name accessor.

--- a/libs/model/src/attr.cpp
+++ b/libs/model/src/attr.cpp
@@ -24,9 +24,21 @@ Attribute::Attribute(Attribute::Data& data, simfil::ModelConstPtr l, simfil::Mod
             });
 }
 
-model_ptr<Geometry> Attribute::validity()
+model_ptr<Geometry> Attribute::validity() const
 {
+    if (!hasValidity())
+        throw std::runtime_error("Attempt to access null validity.");
     return model().resolveGeometry(model_ptr<simfil::ModelNode>::make(model_, data_.validity_));
+}
+
+bool Attribute::hasValidity() const
+{
+    return data_.validity_.value_ != 0;
+}
+
+void Attribute::setValidity(const model_ptr<Geometry>& validityGeom)
+{
+    data_.validity_ = validityGeom->addr();
 }
 
 void Attribute::setDirection(const Attribute::Direction& v)


### PR DESCRIPTION
Adds the previously missing `Attribute::setValidity` API, and introduces additional checks to make sure that the user does not access a null validity.