### PR TITLE
deps/rocksdb: Enable 'PORTABLE' cmake opt to maximize compatibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ if (MAPGET_WITH_SERVICE OR MAPGET_WITH_HTTPLIB OR MAPGET_ENABLE_TESTING)
     set(WITH_BENCHMARK_TOOLS NO CACHE BOOL "rocksdb without benchmarking")
     set(BENCHMARK_ENABLE_GTEST_TESTS NO CACHE BOOL "rocksdb without gtest")
     set(DISABLE_WARNING_AS_ERROR 1 CACHE BOOL "rocksdb warnings are ok")
+    set(PORTABLE YES CACHE BOOL "rocksdb with max compatibility/portability")
 
     FetchContent_Declare(rocksdb
       GIT_REPOSITORY "https://github.com/facebook/rocksdb.git"


### PR DESCRIPTION
This PR is needed that mapget by default builds with portability/compatibility. 

Background: It turned out that rocksdb utilizes by default instructions sets like AVX2 if available on the build system. The downside is that this reduces the number of supported CPUs and therefore machines that can run mapget based applications that are provided as binary packages.