### PR TITLE
fix: missed glm headers while building a conan package

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -52,7 +52,7 @@ class MapgetRecipe(ConanFile):
         self.requires("spdlog/[~1]", transitive_headers=True)
         self.requires("bitsery/[~5]")
         self.requires("nlohmann_json/3.11.2", transitive_headers=True)
-        self.requires("glm/cci.20230113")
+        self.requires("glm/cci.20230113", transitive_headers=True)
         if self.options.with_httplib:
             self.requires("cli11/2.3.2")
             self.requires("cpp-httplib/0.15.3", transitive_headers=True)


### PR DESCRIPTION
I tried `conan create` on mapget and got an error:

> [ 50%] Building CXX object CMakeFiles/test_package.dir/src/example.cpp.o
In file included from /data/users/igor.pugachev/.conan2/p/b/mapgef094bf329d633/p/include/mapget/model/tileid.h:5,
                 from /data/users/igor.pugachev/.conan2/p/b/mapgef094bf329d633/p/include/mapget/model/info.h:9,
                 from /volumes1/workarea/Datasource_DHive/trunk/mapget/test_package/src/example.cpp:1:
/data/users/igor.pugachev/.conan2/p/b/mapgef094bf329d633/p/include/mapget/model/point.h:6:10: fatal error: glm/glm.hpp: No such file or directory
    6 | #include "glm/glm.hpp"
      |          ^~~~~~~~~~~~~
compilation terminated.

Apparently, option `transitive_headers` is needed for glm to make the headers available for the target.