### PR TITLE
Fix overflow issue with z level > 15

### DIFF
--- a/libs/model/include/mapget/model/tileid.h
+++ b/libs/model/include/mapget/model/tileid.h
@@ -64,12 +64,12 @@ struct TileId
     /**
      * Function to get x (column) component of the TileId
      */
-    [[nodiscard]] uint16_t x() const;
+    [[nodiscard]] uint32_t x() const;
 
     /**
      * Function to get y (row) component of the TileId
      */
-    [[nodiscard]] uint16_t y() const;
+    [[nodiscard]] uint32_t y() const;
 
     /**
      * Function to get z (zoom level) component of the TileId (zoom level)

--- a/libs/model/src/tileid.cpp
+++ b/libs/model/src/tileid.cpp
@@ -21,12 +21,12 @@ TileId::TileId(uint64_t value) : value_(value) {
     // No extra work needed here as we directly assign the given value
 }
 
-uint16_t TileId::x() const {
-    return (uint16_t) (value_ >> 32);
+uint32_t TileId::x() const {
+    return (uint32_t) (value_ >> 32);
 }
 
-uint16_t TileId::y() const {
-    return (uint16_t) ((value_ >> 16) & 0xFFFF);
+uint32_t TileId::y() const {
+    return (uint32_t) ((value_ >> 16) & 0xFFFF);
 }
 
 uint16_t TileId::z() const {


### PR DESCRIPTION
When tileId represents tiles with z level over 15, we get numerical overflow issues during bitwise operations with x (and potentially y). To fix those, we have to increase their numerical ranges.