### PR TITLE
Added TileFeatureLayer::find using stringified feature ID.

### DIFF
--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -196,6 +196,7 @@ public:
     model_ptr<Feature> at(size_t i) const;
 
     /** Access feature through its id. */
+    model_ptr<Feature> find(std::string_view const& featureId);
     model_ptr<Feature> find(std::string_view const& type, KeyValueViewPairs const& queryIdParts) const;
     model_ptr<Feature> find(std::string_view const& type, KeyValuePairs const& queryIdParts) const;
 

--- a/test/unit/test-model.cpp
+++ b/test/unit/test-model.cpp
@@ -312,12 +312,19 @@ TEST_CASE("FeatureLayer", "[test.featurelayer]")
         REQUIRE(foundFeature01);
         REQUIRE(foundFeature01->addr() == feature0->addr());
 
+        auto foundFeature01_2 = tile->find("Way.TheBestArea.24");
+        REQUIRE(foundFeature01_2);
+        REQUIRE(foundFeature01_2->addr() == feature0->addr());
+
         auto foundFeature11 = tile->find("Way", KeyValueViewPairs{{"areaId", "TheBestArea"}, {"wayId", 42}});
         REQUIRE(foundFeature11);
         REQUIRE(foundFeature11->addr() == feature1->addr());
 
         auto foundFeature00 = tile->find("Way", KeyValueViewPairs{{"areaId", "MediocreArea"}, {"wayId", 24}});
         REQUIRE(!foundFeature00);
+
+        auto foundFeature00_2 = tile->find("Way.MediocreArea.24");
+        REQUIRE(!foundFeature00_2);
 
         auto foundFeature10 = tile->find("Way", KeyValueViewPairs{{"wayId", 42}});
         REQUIRE(!foundFeature10);


### PR DESCRIPTION
Previously, getting a feature by its ID was only possible with a typeID+KeyValuePairs parameter combo. Now, you can also get it by just using the stringified feature ID, which is much easier as an interface type.