### PR TITLE
config: Avoid race with loader/watcher thread in apps that use mapget.

### DIFF
--- a/libs/service/src/config.cpp
+++ b/libs/service/src/config.cpp
@@ -52,6 +52,10 @@ void DataSourceConfigService::unsubscribe(uint32_t id)
 void DataSourceConfigService::setConfigFilePath(std::string const& path)
 {
     configFilePath_ = path;
+    // Notify subscribers immediately to allow dependent apps to proceed
+    // This is needed as there otherwise apps would have to wait manually
+    // for the callback to be called before they can continue.
+    loadConfig();
     restartFileWatchThread();
 }
 


### PR DESCRIPTION
I am using `mapget` in the following situation (written in shortened pseudo-code):

```cpp
main(args)
{
     service = configService();
     service.subscribe((){
          set(CONFIG_PATH_ENV, service.configPath())     
     });
     return someExternalFuncSettingConfigPath();
}
```
The `someExternalFuncSettingConfigPath()` also relies on the `CONFIG_PATH_ENV` set, this leads to a race.

This workaround suffices for now, but let’s discuss a solution that aligns better with the design principles of ‘mapget’.