### PR TITLE
model: Fix id part value check for unsinged ints.

### DIFF
--- a/libs/model/include/mapget/model/info.h
+++ b/libs/model/include/mapget/model/info.h
@@ -135,7 +135,8 @@ struct IdPart
         uint32_t compositionMatchStartIdx,
         KeyValueViewPairs const& featureIdParts,
         size_t matchLength,
-        bool requireCompositionEnd);
+        bool requireCompositionEnd,
+        std::string* error = nullptr);
 };
 
 /** Structure to represent the feature type info */

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -736,10 +736,19 @@ void TileFeatureLayer::setIdPrefix(const KeyValueViewPairs& prefix)
     // The primary id composition is the first one in the list.
     for (auto& featureType : this->layerInfo_->featureTypes_) {
         for (auto& candidateComposition : featureType.uniqueIdCompositions_) {
-            if (!IdPart::idPartsMatchComposition(candidateComposition, 0, prefix, prefix.size(), false)) {
+            std::string error;
+            auto compositionMatched = IdPart::idPartsMatchComposition(
+                candidateComposition,
+                0,
+                prefix,
+                prefix.size(),
+                false,
+                &error);
+            if (!compositionMatched) {
                 raise(fmt::format(
-                    "Prefix not compatible with an id composite in type: {}",
-                    featureType.name_));
+                    "Tile feature ID prefix is not compatible with an id composite in type {}: {}",
+                    featureType.name_,
+                    error));
             }
             break;
         }

--- a/libs/model/src/info.cpp
+++ b/libs/model/src/info.cpp
@@ -114,7 +114,8 @@ bool IdPart::idPartsMatchComposition(
     uint32_t compositionMatchStartIdx,
     const KeyValueViewPairs& featureIdParts,
     size_t matchLength,
-    bool requireCompositionEnd)
+    bool requireCompositionEnd,
+    std::string* error)
 {
     auto featureIdIter = featureIdParts.begin();
     auto compositionIter = candidateComposition.begin();
@@ -142,7 +143,7 @@ bool IdPart::idPartsMatchComposition(
         }
 
         // Does the ID part's value match?
-        if (!compositionIter->validate(idPartValue))
+        if (!compositionIter->validate(idPartValue, error))
             return false;
 
         ++featureIdIter;


### PR DESCRIPTION
Fixes #86 

In addition to this pure fix we should also expose the exact error - the generic error message made it unnecessary hard to identify the root cause. The `validate` methods already support the optional error string which will be filled with a precise error description. But this string parameter is not used and the entry-point of the API doesn't expose it.