### PR TITLE
Use picosha2 1.0.1

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -59,6 +59,7 @@ class MapgetRecipe(ConanFile):
             self.requires("cpp-httplib/0.15.3", transitive_headers=True)
             self.requires("yaml-cpp/0.8.0")
             self.requires("json-schema-validator/2.3.0")
+            # TODO: Use picosha2 1.0.1+ (not yet available via conan)
             self.requires("picosha2/cci.20220808", transitive_headers=True)
         if self.options.with_service or self.options.with_httplib:
             self.requires("rocksdb/9.1.0")

--- a/deps.cmake
+++ b/deps.cmake
@@ -74,7 +74,7 @@ else()
 
   FetchContent_Declare(picosha2
     GIT_REPOSITORY "https://github.com/okdshin/PicoSHA2"
-    GIT_TAG        "27fcf6979298949e8a462e16d09a0351c18fcaf2"
+    GIT_TAG        "v1.0.1"
     GIT_SHALLOW    ON)
 
   if (MAPGET_WITH_WHEEL AND NOT TARGET pybind11)


### PR DESCRIPTION
This PR updates picosha2 as the old used commit id is no longer available via shallow cloning and there is now a new official release (v1.0.1) - Unfortunately there is not yet a Conan release available, therefore I left a comment in the conan cfg.