### PR TITLE
Separated setConfigFile and loadConfig.

### DIFF
--- a/libs/http-service/src/cli.cpp
+++ b/libs/http-service/src/cli.cpp
@@ -246,7 +246,12 @@ struct ServeCommand
             DataSourceConfigService::get().setConfigFilePath(config->as<std::string>());
         }
 
+
+        // HttpService will subscribe to DataSourceConfigService.
         HttpService srv(cache, watchConfig);
+
+        // Load config and reload if changes occur.
+        DataSourceConfigService::get().startConfigFileWatchThread();
 
         if (!datasourceHosts_.empty()) {
             for (auto& ds : datasourceHosts_) {

--- a/libs/service/include/mapget/service/config.h
+++ b/libs/service/include/mapget/service/config.h
@@ -86,6 +86,11 @@ public:
     std::optional<std::string> getConfigFilePath() const;
 
     /**
+     * Loads the configuration and starts watching the configuration file for changes.
+     */
+    void startConfigFileWatchThread();
+
+    /**
      * Instantiates a data source based on the provided descriptor.
      * @param descriptor The YAML node containing the data source descriptor.
      * @return Shared pointer to the instantiated data source, or nullptr if instantiation failed.
@@ -124,12 +129,6 @@ private:
      */
     void loadConfig();
 
-    /**
-     * Starts watching the configuration file for changes.
-     * @param path The file path to the YAML configuration file.
-     */
-    void restartFileWatchThread();
-
     // Path to the configuration file.
     std::string configFilePath_;
 
@@ -157,6 +156,9 @@ private:
 
     // Mutex to ensure that currentConfig_ and subscriptions_ are safely accessed.
     std::recursive_mutex memberAccessMutex_;
+
+    // Once the config file has been loaded, subscriptions are blocked.
+    bool blockedSubscriptions_ = false;
 };
 
 }  // namespace mapget


### PR DESCRIPTION
To me, the most sensible approach is to separate setConfigFile from the actual loading of the config file. Open to other opinions, of course.