### PR TITLE
ci: Enable Apple Silicon and Linux arm64 versions of mapget python.

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -10,9 +10,10 @@ jobs:
   build-manylinux:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-    runs-on: ubuntu-latest
-    container: ghcr.io/klebert-engineering/manylinux-cpp17-py${{ matrix.python-version }}-x86_64:2024.2
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        arch: ["x86_64", "aarch64"]
+    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    container: ghcr.io/klebert-engineering/manylinux-cpp17-py${{ matrix.python-version }}-${{ matrix.arch }}:2025.1
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       SCCACHE_GHA_ENABLED: "true"
@@ -52,14 +53,18 @@ jobs:
       - name: Deploy
         uses: actions/upload-artifact@v4
         with:
-          name: mapget-py${{ matrix.python-version }}-ubuntu-latest
-          path: build/bin/wheel/*.whl
+          name: mapget-py${{ matrix.python-version }}-ubuntu-latest-${{ matrix.arch }}
+          path: build/Release/bin/wheel/*.whl
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, windows-2022]  # Currently, macos-latest is macos 12
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        os: [macos-13, macos-14, windows-2022]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        exclude:
+          # Python 3.10 doesn't have ARM64 builds for macOS
+          - os: macos-14
+            python-version: "3.10"
     env:
       SCCACHE_GHA_ENABLED: "true"
     steps:
@@ -74,10 +79,16 @@ jobs:
           architecture: x64
       - run: python -m pip install setuptools wheel ninja
       - name: Build (macOS)
-        if: matrix.os == 'macos-13'
+        if: startsWith(matrix.os, 'macos')
         run: |
           python -m pip install delocate
-          export MACOSX_DEPLOYMENT_TARGET=10.15
+          # Set deployment target based on architecture
+          # macos-13 = Intel x86_64, macos-14 = Apple Silicon arm64
+          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+            export MACOSX_DEPLOYMENT_TARGET=10.15
+          else
+            export MACOSX_DEPLOYMENT_TARGET=11.0  # ARM64 requires macOS 11.0+
+          fi
           mkdir -p build && cd build
           cmake .. -DCMAKE_BUILD_TYPE=Release \
                 -DPython3_ROOT_DIR="$pythonLocation" \
@@ -85,6 +96,7 @@ jobs:
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
                 -DMAPGET_ENABLE_TESTING=ON \
+                -DMAPGET_BUILD_EXAMPLES=ON \
                 -DMAPGET_WITH_WHEEL=True \
                 -DMAPGET_WITH_SERVICE=True \
                 -DMAPGET_WITH_HTTPLIB=True \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,8 +7,12 @@ jobs:
   deploy:
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
-        os: [macos-13, ubuntu-latest, windows-2022]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        os: [macos-13, macos-14, ubuntu-latest-x86_64, ubuntu-latest-aarch64, windows-2019]
+        exclude:
+          # Python 3.10 doesn't have ARM64 builds for macOS
+          - os: macos-14
+            python-version: "3.10"
     runs-on: ubuntu-latest
     steps:
       - name: Fetch
@@ -17,7 +21,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           workflow: cmake.yaml
-          name: mapget-py${{ matrix.python-version }}-${{ matrix.os }}
+          name: mapget-py${{ matrix.python-version }}-${{ matrix.os == 'ubuntu-latest-x86_64' && 'ubuntu-latest-x86_64' || matrix.os == 'ubuntu-latest-aarch64' && 'ubuntu-latest-aarch64' || matrix.os }}
           path: dist/
       - name: Upload
         env:

--- a/deps.cmake
+++ b/deps.cmake
@@ -154,7 +154,7 @@ endif()
 if (MAPGET_WITH_WHEEL AND NOT TARGET python-cmake-wheel)
   FetchContent_Declare(python-cmake-wheel
     GIT_REPOSITORY "https://github.com/klebert-engineering/python-cmake-wheel.git"
-    GIT_TAG        "v0.9.0"
+    GIT_TAG        "v1.0.0"
     GIT_SHALLOW    ON)
   FetchContent_MakeAvailable(python-cmake-wheel)
 endif()


### PR DESCRIPTION
Add ARM64 (Apple Silicon and Linux aarch64) support for mapget Python bindings

• Update CI to build Python wheels for ARM64 on macOS 14 (Apple Silicon) and Linux aarch64
• Add Python 3.13 support across all platforms
• Drop Python 3.9 support (EOL)
• Set appropriate MACOSX_DEPLOYMENT_TARGET for each architecture (10.15 for x86_64, 11.0 for ARM64)
• Update manylinux container to 2025.1 for ARM64 compatibility