### PR TITLE
Introduction of SQLite based persistent cache ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,8 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(MAPGET_WITH_WHEEL ON CACHE BOOL "Enable mapget Python wheel (output to WHEEL_DEPLOY_DIRECTORY).")
   set(MAPGET_WITH_SERVICE ON CACHE BOOL "Enable mapget-service library. Requires threads.")
   set(MAPGET_WITH_HTTPLIB ON CACHE BOOL "Enable mapget-http-datasource and mapget-http-service libraries.")
-  set(MAPGET_WITH_ROCKSDB ON CACHE BOOL "Enable RocksDB persistent cache support.")
+  set(MAPGET_WITH_ROCKSDB OFF CACHE BOOL "Enable RocksDB persistent cache support.")
+  set(MAPGET_WITH_SQLITE ON CACHE BOOL "Enable SQLite persistent cache support.")
   set(MAPGET_ENABLE_TESTING ON CACHE BOOL "Enable testing.")
   set(MAPGET_BUILD_EXAMPLES ON CACHE BOOL "Build examples.")
 endif()
@@ -25,6 +26,7 @@ option(MAPGET_WITH_WHEEL "Enable mapget Python wheel (output to WHEEL_DEPLOY_DIR
 option(MAPGET_WITH_SERVICE "Enable mapget-service library. Requires threads.")
 option(MAPGET_WITH_HTTPLIB "Enable mapget-http-datasource and mapget-http-service libraries.")
 option(MAPGET_WITH_ROCKSDB "Enable RocksDB persistent cache support.")
+option(MAPGET_WITH_SQLITE "Enable SQLite persistent cache support.")
 
 set(Python3_FIND_STRATEGY LOCATION)
 

--- a/libs/service/CMakeLists.txt
+++ b/libs/service/CMakeLists.txt
@@ -21,6 +21,12 @@ if (MAPGET_WITH_ROCKSDB)
     src/rocksdbcache.cpp)
 endif()
 
+if (MAPGET_WITH_SQLITE)
+  list(APPEND MAPGET_SERVICE_SOURCES
+    include/mapget/service/sqlitecache.h
+    src/sqlitecache.cpp)
+endif()
+
 add_library(mapget-service STATIC ${MAPGET_SERVICE_SOURCES})
 
 target_include_directories(mapget-service
@@ -40,6 +46,11 @@ target_link_libraries(mapget-service
 if (MAPGET_WITH_ROCKSDB)
   target_link_libraries(mapget-service PUBLIC RocksDB::rocksdb)
   target_compile_definitions(mapget-service PUBLIC MAPGET_WITH_ROCKSDB)
+endif()
+
+if (MAPGET_WITH_SQLITE)
+  target_link_libraries(mapget-service PUBLIC SQLite3)
+  target_compile_definitions(mapget-service PUBLIC MAPGET_WITH_SQLITE)
 endif()
 
 if (MSVC)

--- a/libs/service/include/mapget/service/sqlitecache.h
+++ b/libs/service/include/mapget/service/sqlitecache.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "cache.h"
+
+#ifdef MAPGET_WITH_SQLITE
+#include <sqlite3.h>
+#include <memory>
+#include <string>
+#endif
+
+namespace mapget
+{
+
+#ifdef MAPGET_WITH_SQLITE
+
+/**
+ * A persistent cache implementation that stores layers and string pools
+ * in SQLite. Oldest tiles are removed automatically in FIFO order when cacheMaxTiles is
+ * reached.
+ */
+class SQLiteCache : public Cache
+{
+public:
+    explicit SQLiteCache(
+        uint32_t cacheMaxTiles = 1024,
+        std::string cachePath = "mapget-cache.db",
+        bool clearCache = false);
+    ~SQLiteCache() override;
+
+    std::optional<std::string> getTileLayerBlob(MapTileKey const& k) override;
+    void putTileLayerBlob(MapTileKey const& k, std::string const& v) override;
+    std::optional<std::string> getStringPoolBlob(std::string_view const& sourceNodeId) override;
+    void putStringPoolBlob(std::string_view const& sourceNodeId, std::string const& v) override;
+
+private:
+    void initDatabase();
+    void executeSQL(const std::string& sql);
+    void prepareStatements();
+    void cleanupOldestTiles();
+
+    sqlite3* db_{nullptr};
+    std::string dbPath_;
+    uint32_t maxTileCount_;
+    bool clearCache_;
+
+    // Prepared statements for performance
+    struct Statements {
+        sqlite3_stmt* getTile{nullptr};
+        sqlite3_stmt* putTile{nullptr};
+        sqlite3_stmt* updateTileTimestamp{nullptr};
+        sqlite3_stmt* deleteTile{nullptr};
+        sqlite3_stmt* getStringPool{nullptr};
+        sqlite3_stmt* putStringPool{nullptr};
+        sqlite3_stmt* getOldestTile{nullptr};
+        sqlite3_stmt* getTileCount{nullptr};
+    } stmts_;
+};
+
+#else
+
+/**
+ * Stub implementation when SQLite is disabled at compile time.
+ * Throws an exception when instantiated.
+ */
+class SQLiteCache : public Cache
+{
+public:
+    explicit SQLiteCache(
+        uint32_t cacheMaxTiles = 1024,
+        std::string cachePath = "mapget-cache.db",
+        bool clearCache = false)
+    {
+        throw std::runtime_error("SQLite support was disabled at compile time. Use -DMAPGET_WITH_SQLITE=ON to enable it.");
+    }
+
+    std::optional<std::string> getTileLayerBlob(MapTileKey const& k) override { return {}; }
+    void putTileLayerBlob(MapTileKey const& k, std::string const& v) override {}
+    std::optional<std::string> getStringPoolBlob(std::string_view const& sourceNodeId) override { return {}; }
+    void putStringPoolBlob(std::string_view const& sourceNodeId, std::string const& v) override {}
+};
+
+#endif
+
+}  // namespace mapget

--- a/libs/service/src/sqlitecache.cpp
+++ b/libs/service/src/sqlitecache.cpp
@@ -1,0 +1,312 @@
+#ifdef MAPGET_WITH_SQLITE
+#include <sqlite3.h>
+#endif
+#include <filesystem>
+#include <iostream>
+#include <chrono>
+
+#include "mapget/log.h"
+#include "sqlitecache.h"
+
+namespace mapget
+{
+
+#ifdef MAPGET_WITH_SQLITE
+
+SQLiteCache::SQLiteCache(uint32_t cacheMaxTiles, std::string cachePath, bool clearCache)
+    : maxTileCount_(cacheMaxTiles), dbPath_(cachePath), clearCache_(clearCache)
+{
+    namespace fs = std::filesystem;
+
+    fs::path absoluteCachePath = cachePath;
+    if (fs::path(cachePath).is_relative()) {
+        absoluteCachePath = fs::current_path() / cachePath;
+    }
+    dbPath_ = absoluteCachePath.string();
+    
+    log().debug(fmt::format("Initializing SQLite cache at: {}", dbPath_));
+
+    if (!fs::exists(absoluteCachePath.parent_path())) {
+        raiseFmt("Error initializing SQLite cache: parent directory {} does not exist!",
+            absoluteCachePath.parent_path().string());
+    }
+
+    if (clearCache && fs::exists(absoluteCachePath)) {
+        fs::remove(absoluteCachePath);
+    }
+
+    // Open the database
+    int rc = sqlite3_open(dbPath_.c_str(), &db_);
+    if (rc != SQLITE_OK) {
+        raise(fmt::format("Error opening SQLite database at {}: {}",
+            dbPath_, sqlite3_errmsg(db_)));
+    }
+
+    // Enable WAL mode for better concurrency
+    executeSQL("PRAGMA journal_mode=WAL");
+    executeSQL("PRAGMA synchronous=NORMAL");
+
+    initDatabase();
+    prepareStatements();
+
+    // Count existing tiles
+    sqlite3_stmt* stmt;
+    rc = sqlite3_prepare_v2(db_, "SELECT COUNT(*) FROM tiles", -1, &stmt, nullptr);
+    if (rc == SQLITE_OK) {
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            int count = sqlite3_column_int(stmt, 0);
+            log().debug(fmt::format("Initialized SQLite cache with {} existing tile entries.", count));
+            
+            // Handle special case: if the cache has more tiles than the limit
+            if (!clearCache && maxTileCount_ > 0 && count > maxTileCount_) {
+                int deleteCount = count - maxTileCount_;
+                std::string sql = fmt::format(
+                    "DELETE FROM tiles WHERE key IN (SELECT key FROM tiles ORDER BY timestamp ASC LIMIT {})",
+                    deleteCount);
+                executeSQL(sql);
+            }
+        }
+        sqlite3_finalize(stmt);
+    }
+
+    // Update stringPoolOffsets_ for each existing string pool
+    rc = sqlite3_prepare_v2(db_, "SELECT node_id FROM string_pools", -1, &stmt, nullptr);
+    if (rc == SQLITE_OK) {
+        while (sqlite3_step(stmt) == SQLITE_ROW) {
+            const char* nodeId = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+            if (nodeId) {
+                // Trigger cache lookup to update offsets
+                Cache::getStringPool(nodeId);
+            }
+        }
+        sqlite3_finalize(stmt);
+    }
+}
+
+SQLiteCache::~SQLiteCache()
+{
+    // Clean up prepared statements
+    if (stmts_.getTile) sqlite3_finalize(stmts_.getTile);
+    if (stmts_.putTile) sqlite3_finalize(stmts_.putTile);
+    if (stmts_.updateTileTimestamp) sqlite3_finalize(stmts_.updateTileTimestamp);
+    if (stmts_.deleteTile) sqlite3_finalize(stmts_.deleteTile);
+    if (stmts_.getStringPool) sqlite3_finalize(stmts_.getStringPool);
+    if (stmts_.putStringPool) sqlite3_finalize(stmts_.putStringPool);
+    if (stmts_.getOldestTile) sqlite3_finalize(stmts_.getOldestTile);
+    if (stmts_.getTileCount) sqlite3_finalize(stmts_.getTileCount);
+
+    if (db_) {
+        sqlite3_close(db_);
+    }
+}
+
+void SQLiteCache::initDatabase()
+{
+    // Create tiles table with timestamp for FIFO eviction
+    executeSQL(R"(
+        CREATE TABLE IF NOT EXISTS tiles (
+            key TEXT PRIMARY KEY,
+            data BLOB NOT NULL,
+            timestamp INTEGER NOT NULL
+        )
+    )");
+
+    // Create index on timestamp for efficient FIFO eviction
+    executeSQL("CREATE INDEX IF NOT EXISTS idx_tiles_timestamp ON tiles(timestamp ASC)");
+
+    // Create string pools table
+    executeSQL(R"(
+        CREATE TABLE IF NOT EXISTS string_pools (
+            node_id TEXT PRIMARY KEY,
+            data BLOB NOT NULL
+        )
+    )");
+}
+
+void SQLiteCache::executeSQL(const std::string& sql)
+{
+    char* errMsg = nullptr;
+    int rc = sqlite3_exec(db_, sql.c_str(), nullptr, nullptr, &errMsg);
+    if (rc != SQLITE_OK) {
+        std::string error = errMsg ? errMsg : "Unknown error";
+        sqlite3_free(errMsg);
+        raise(fmt::format("SQLite error executing '{}': {}", sql, error));
+    }
+}
+
+void SQLiteCache::prepareStatements()
+{
+    int rc;
+
+    // Prepare statement for getting tiles
+    rc = sqlite3_prepare_v2(db_,
+        "SELECT data FROM tiles WHERE key = ?",
+        -1, &stmts_.getTile, nullptr);
+    if (rc != SQLITE_OK) {
+        raise(fmt::format("Failed to prepare getTile statement: {}", sqlite3_errmsg(db_)));
+    }
+
+    // Prepare statement for inserting/updating tiles
+    rc = sqlite3_prepare_v2(db_,
+        "INSERT OR REPLACE INTO tiles (key, data, timestamp) VALUES (?, ?, ?)",
+        -1, &stmts_.putTile, nullptr);
+    if (rc != SQLITE_OK) {
+        raise(fmt::format("Failed to prepare putTile statement: {}", sqlite3_errmsg(db_)));
+    }
+
+    // Prepare statement for updating tile timestamp
+    rc = sqlite3_prepare_v2(db_,
+        "UPDATE tiles SET timestamp = ? WHERE key = ?",
+        -1, &stmts_.updateTileTimestamp, nullptr);
+    if (rc != SQLITE_OK) {
+        raise(fmt::format("Failed to prepare updateTileTimestamp statement: {}", sqlite3_errmsg(db_)));
+    }
+
+    // Prepare statement for deleting tiles
+    rc = sqlite3_prepare_v2(db_,
+        "DELETE FROM tiles WHERE key = ?",
+        -1, &stmts_.deleteTile, nullptr);
+    if (rc != SQLITE_OK) {
+        raise(fmt::format("Failed to prepare deleteTile statement: {}", sqlite3_errmsg(db_)));
+    }
+
+    // Prepare statement for getting string pools
+    rc = sqlite3_prepare_v2(db_,
+        "SELECT data FROM string_pools WHERE node_id = ?",
+        -1, &stmts_.getStringPool, nullptr);
+    if (rc != SQLITE_OK) {
+        raise(fmt::format("Failed to prepare getStringPool statement: {}", sqlite3_errmsg(db_)));
+    }
+
+    // Prepare statement for inserting/updating string pools
+    rc = sqlite3_prepare_v2(db_,
+        "INSERT OR REPLACE INTO string_pools (node_id, data) VALUES (?, ?)",
+        -1, &stmts_.putStringPool, nullptr);
+    if (rc != SQLITE_OK) {
+        raise(fmt::format("Failed to prepare putStringPool statement: {}", sqlite3_errmsg(db_)));
+    }
+
+    // Prepare statement for getting oldest tile
+    rc = sqlite3_prepare_v2(db_,
+        "SELECT key FROM tiles ORDER BY timestamp ASC LIMIT 1",
+        -1, &stmts_.getOldestTile, nullptr);
+    if (rc != SQLITE_OK) {
+        raise(fmt::format("Failed to prepare getOldestTile statement: {}", sqlite3_errmsg(db_)));
+    }
+
+    // Prepare statement for counting tiles
+    rc = sqlite3_prepare_v2(db_,
+        "SELECT COUNT(*) FROM tiles",
+        -1, &stmts_.getTileCount, nullptr);
+    if (rc != SQLITE_OK) {
+        raise(fmt::format("Failed to prepare getTileCount statement: {}", sqlite3_errmsg(db_)));
+    }
+}
+
+std::optional<std::string> SQLiteCache::getTileLayerBlob(MapTileKey const& k)
+{
+    sqlite3_reset(stmts_.getTile);
+    sqlite3_bind_text(stmts_.getTile, 1, k.toString().c_str(), -1, SQLITE_TRANSIENT);
+
+    int rc = sqlite3_step(stmts_.getTile);
+    if (rc == SQLITE_ROW) {
+        const void* data = sqlite3_column_blob(stmts_.getTile, 0);
+        int size = sqlite3_column_bytes(stmts_.getTile, 0);
+        std::string result(static_cast<const char*>(data), size);
+        
+        log().trace(fmt::format("Key: {} | Layer size: {}", k.toString(), size));
+        log().debug("Cache hits: {}, cache misses: {}", ++cacheHits_, cacheMisses_);
+        return result;
+    }
+    else if (rc == SQLITE_DONE) {
+        log().debug("Cache hits: {}, cache misses: {}", cacheHits_, ++cacheMisses_);
+        return {};
+    }
+    else {
+        raise(fmt::format("Error reading from database: {}", sqlite3_errmsg(db_)));
+    }
+}
+
+void SQLiteCache::putTileLayerBlob(MapTileKey const& k, std::string const& v)
+{
+    auto timestamp = std::chrono::system_clock::now().time_since_epoch().count();
+
+    sqlite3_reset(stmts_.putTile);
+    sqlite3_bind_text(stmts_.putTile, 1, k.toString().c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_blob(stmts_.putTile, 2, v.data(), v.size(), SQLITE_TRANSIENT);
+    sqlite3_bind_int64(stmts_.putTile, 3, timestamp);
+
+    int rc = sqlite3_step(stmts_.putTile);
+    if (rc != SQLITE_DONE) {
+        raise(fmt::format("Error writing to database: {}", sqlite3_errmsg(db_)));
+    }
+
+    log().debug("Cache hits: {}, cache misses: {}", cacheHits_, cacheMisses_);
+
+    // Check if we need to evict old tiles
+    if (maxTileCount_ > 0) {
+        sqlite3_reset(stmts_.getTileCount);
+        if (sqlite3_step(stmts_.getTileCount) == SQLITE_ROW) {
+            int count = sqlite3_column_int(stmts_.getTileCount, 0);
+            if (count > maxTileCount_) {
+                cleanupOldestTiles();
+            }
+        }
+    }
+}
+
+void SQLiteCache::cleanupOldestTiles()
+{
+    // Delete the oldest tile
+    sqlite3_reset(stmts_.getOldestTile);
+    if (sqlite3_step(stmts_.getOldestTile) == SQLITE_ROW) {
+        const char* oldestKey = reinterpret_cast<const char*>(sqlite3_column_text(stmts_.getOldestTile, 0));
+        if (oldestKey) {
+            sqlite3_reset(stmts_.deleteTile);
+            sqlite3_bind_text(stmts_.deleteTile, 1, oldestKey, -1, SQLITE_TRANSIENT);
+            
+            int rc = sqlite3_step(stmts_.deleteTile);
+            if (rc != SQLITE_DONE) {
+                raise(fmt::format("Could not delete oldest cache entry: {}", sqlite3_errmsg(db_)));
+            }
+        }
+    }
+}
+
+std::optional<std::string> SQLiteCache::getStringPoolBlob(std::string_view const& sourceNodeId)
+{
+    sqlite3_reset(stmts_.getStringPool);
+    sqlite3_bind_text(stmts_.getStringPool, 1, sourceNodeId.data(), sourceNodeId.size(), SQLITE_TRANSIENT);
+
+    int rc = sqlite3_step(stmts_.getStringPool);
+    if (rc == SQLITE_ROW) {
+        const void* data = sqlite3_column_blob(stmts_.getStringPool, 0);
+        int size = sqlite3_column_bytes(stmts_.getStringPool, 0);
+        std::string result(static_cast<const char*>(data), size);
+        
+        log().trace(fmt::format("Node: {} | String pool size: {}", sourceNodeId, size));
+        return result;
+    }
+    else if (rc == SQLITE_DONE) {
+        return {};
+    }
+    else {
+        raise(fmt::format("Error reading from database: {}", sqlite3_errmsg(db_)));
+    }
+}
+
+void SQLiteCache::putStringPoolBlob(std::string_view const& sourceNodeId, std::string const& v)
+{
+    sqlite3_reset(stmts_.putStringPool);
+    sqlite3_bind_text(stmts_.putStringPool, 1, sourceNodeId.data(), sourceNodeId.size(), SQLITE_TRANSIENT);
+    sqlite3_bind_blob(stmts_.putStringPool, 2, v.data(), v.size(), SQLITE_TRANSIENT);
+
+    int rc = sqlite3_step(stmts_.putStringPool);
+    if (rc != SQLITE_DONE) {
+        raise(fmt::format("Error writing to database: {}", sqlite3_errmsg(db_)));
+    }
+}
+
+#endif  // MAPGET_WITH_SQLITE
+
+}  // namespace mapget

--- a/test/unit/test-cache.cpp
+++ b/test/unit/test-cache.cpp
@@ -10,10 +10,14 @@
 #include "mapget/log.h"
 #include "mapget/model/featurelayer.h"
 #include "mapget/model/info.h"
+#ifdef MAPGET_WITH_ROCKSDB
 #include "mapget/service/rocksdbcache.h"
+#endif
+#include "mapget/service/sqlitecache.h"
 
 using namespace mapget;
 
+#ifdef MAPGET_WITH_ROCKSDB
 TEST_CASE("RocksDBCache", "[Cache]")
 {
     mapget::setLogLevel("trace", log());
@@ -244,6 +248,237 @@ TEST_CASE("RocksDBCache", "[Cache]")
 
         // Create cache and make sure it worked.
         auto cache = std::make_shared<mapget::RocksDBCache>(
+            1024, test_cache.string(), true);
+        REQUIRE(std::filesystem::exists(test_cache));
+    }
+}
+#endif // MAPGET_WITH_ROCKSDB
+
+TEST_CASE("SQLiteCache", "[Cache]")
+{
+    mapget::setLogLevel("trace", log());
+
+    auto layerInfo = LayerInfo::fromJson(R"({
+        "layerId": "WayLayer",
+        "type": "Features",
+        "featureTypes": [
+            {
+                "name": "Way",
+                "uniqueIdCompositions": [
+                    [
+                        {
+                            "partId": "areaId",
+                            "description": "String identifying the map area.",
+                            "datatype": "STR"
+                        },
+                        {
+                            "partId": "wayId",
+                            "description": "Globally Unique 32b integer.",
+                            "datatype": "U32"
+                        }
+                    ]
+                ]
+            }
+        ]
+    })"_json);
+
+    // Create one LayerInfo to be re-used by all DataSourceInfos.
+    std::unordered_map<std::string, std::shared_ptr<LayerInfo>> layers;
+    layers[layerInfo->layerId_] = std::make_shared<LayerInfo>(LayerInfo{
+        layerInfo->layerId_,
+        layerInfo->type_,
+        std::vector<FeatureTypeInfo>(),
+        std::vector<int>{0, 1, 2},
+        std::vector<Coverage>{{1, 2, {}}, {3, 3, {}}},
+        true,
+        false,
+        Version{0, 0, 0}});
+
+    // Create a basic TileFeatureLayer.
+    auto tileId = TileId::fromWgs84(42., 11., 13);
+    auto nodeId = "SQLiteCacheTestingNode";
+    auto mapId = "CacheMe";
+    // Create empty shared autofilled string dictionary.
+    auto strings = std::make_shared<StringPool>(nodeId);
+    auto tile = std::make_shared<TileFeatureLayer>(
+        tileId,
+        nodeId,
+        mapId,
+        layerInfo,
+        strings);
+    // Create a DataSourceInfo object.
+    DataSourceInfo info(DataSourceInfo{
+        nodeId,
+        mapId,
+        layers,
+        5,
+        false,
+        nlohmann::json::object(),
+        TileLayerStream::CurrentProtocolVersion});
+
+    // Create another basic TileFeatureLayer for a different node.
+    auto otherTileId = TileId::fromWgs84(42., 12., 13);
+    auto otherNodeId = "OtherSQLiteCacheTestingNode";
+    auto otherMapId = "CacheMeToo";
+    // Create empty shared autofilled string-pool.
+    auto otherStringPool = std::make_shared<StringPool>(otherNodeId);
+    auto otherTile = std::make_shared<TileFeatureLayer>(
+        otherTileId,
+        otherNodeId,
+        otherMapId,
+        layerInfo,
+        otherStringPool);
+    // Create another DataSourceInfo object, but reuse the layer info.
+    DataSourceInfo otherInfo(DataSourceInfo{
+        otherNodeId,
+        otherMapId,
+        layers,
+        5,
+        false,
+        nlohmann::json::object(),
+        TileLayerStream::CurrentProtocolVersion});
+
+
+    auto testStringPoolNodeId = "SQLiteStringPoolTestingNode";
+    auto testStringPool = StringPool(testStringPoolNodeId);
+
+    // Write a string pool directly into the cache, including the header
+    // added in TileLayerStream::sendMessage.
+    std::stringstream serializedStrings;
+    testStringPool.write(serializedStrings, 0);
+
+    std::stringstream serializedMessage;
+    bitsery::Serializer<bitsery::OutputStreamAdapter> s(serializedMessage);
+    s.object(TileLayerStream::CurrentProtocolVersion);
+    s.value1b(TileLayerStream::MessageType::StringPool);
+    s.value4b((uint32_t)serializedStrings.str().size());
+    serializedMessage << serializedStrings.str();
+
+    auto getFeatureLayer = [](auto& cache, auto tileId, auto info) {
+        auto layer = cache->getTileLayer(tileId, info);
+        REQUIRE(!!layer);
+
+        auto layerInfo = layer->layerInfo();
+        REQUIRE(!!layerInfo);
+        REQUIRE(layerInfo->type_ == mapget::LayerType::Features);
+        return std::static_pointer_cast<TileFeatureLayer>(layer);
+    };
+
+    SECTION("Insert, retrieve, and update feature layer") {
+        // Open or create cache, clear any existing data.
+        auto cache = std::make_shared<mapget::SQLiteCache>(
+            1024, "mapget-cache.db", true);
+        auto stringPoolCount = cache->getStatistics()["loaded-string-pools"].get<int>();
+        REQUIRE(stringPoolCount == 0);
+
+        // putTileLayer triggers both putTileLayerBlob and putFieldsBlob.
+        cache->putTileLayer(tile);
+        auto returnedTile = getFeatureLayer(cache, tile->id(), info);
+        stringPoolCount = cache->getStatistics()["loaded-string-pools"].get<int>();
+        REQUIRE(stringPoolCount == 1);
+
+        // Update a tile, check that cache returns the updated version.
+        REQUIRE(returnedTile->size() == 0);
+        auto feature = tile->newFeature("Way", {{"areaId", "MediocreArea"}, {"wayId", 24}});
+        cache->putTileLayer(tile);
+        auto updatedTile = getFeatureLayer(cache, tile->id(), info);
+        REQUIRE(updatedTile->size() == 1);
+
+        // Check that cache hits and misses are properly recorded.
+        auto missingTile = cache->getTileLayer(otherTile->id(), otherInfo);
+        REQUIRE(cache->getStatistics()["cache-hits"] == 2);
+        REQUIRE(cache->getStatistics()["cache-misses"] == 1);
+    }
+
+    SECTION("Reopen cache with maxTileCount=1, insert another layer") {
+        // Open existing cache.
+        auto cache = std::make_shared<mapget::SQLiteCache>(
+            1, "mapget-cache.db", false);
+        auto stringPoolCount = cache->getStatistics()["loaded-string-pools"].get<int>();
+        REQUIRE(stringPoolCount == 1);
+
+        // Add a tile to trigger cache cleaning.
+        cache->putTileLayer(otherTile);
+
+        auto returnedTile = getFeatureLayer(cache, otherTile->id(), otherInfo);
+        REQUIRE(returnedTile->nodeId() == otherTile->nodeId());
+
+        // String pools are updated with getTileLayer.
+        stringPoolCount = cache->getStatistics()["loaded-string-pools"].get<int>();
+        REQUIRE(stringPoolCount == 2);
+
+        // Query the first inserted layer - it should not be retrievable.
+        auto missingTile = cache->getTileLayer(tile->id(), info);
+        REQUIRE(cache->getStatistics()["cache-misses"] == 1);
+        REQUIRE(!missingTile);
+    }
+
+    SECTION("Store another tile at unlimited cache size") {
+        auto cache = std::make_shared<mapget::SQLiteCache>(
+            0, "mapget-cache.db", false);
+
+        // Insert another tile for the next test.
+        cache->putTileLayer(tile);
+
+        // Make sure the previous tile is still there, since cache is unlimited.
+        auto olderTile = cache->getTileLayer(otherTile->id(), otherInfo);
+        REQUIRE(cache->getStatistics()["cache-misses"] == 0);
+        REQUIRE(cache->getStatistics()["cache-hits"] == 1);
+    }
+
+    SECTION("Reopen cache with maxTileCount=1, check older tile was deleted") {
+        auto cache = std::make_shared<mapget::SQLiteCache>(
+            1, "mapget-cache.db", false);
+        REQUIRE(cache->getStatistics()["cache-misses"] == 0);
+
+        // Query the first inserted layer - it should not be retrievable.
+        auto missingTile = cache->getTileLayer(otherTile->id(), otherInfo);
+        REQUIRE(cache->getStatistics()["cache-misses"] == 1);
+    }
+
+    SECTION("Reopen cache, check loading of string pools") {
+        // Open existing cache.
+        auto cache = std::make_shared<mapget::SQLiteCache>();
+        REQUIRE(cache->getStatistics()["loaded-string-pools"] == 2);
+
+        cache->putStringPoolBlob(testStringPoolNodeId, serializedMessage.str());
+        auto returnedEntry = cache->getStringPoolBlob(testStringPoolNodeId);
+
+        // Make sure the string pool was properly stored.
+        REQUIRE(returnedEntry.value() == serializedMessage.str());
+
+        // TODO this kind of access bypasses the creation of a stringPoolOffsets_
+        //  entry in the cache -> decouple the cache storage logic clearly from
+        //  tile layer writing logic.
+        REQUIRE(cache->getStatistics()["loaded-string-pools"] == 2);
+    }
+
+    SECTION("Reopen cache again, check loading of string pools again") {
+        // Open existing cache.
+        auto cache = std::make_shared<mapget::SQLiteCache>();
+        REQUIRE(cache->getStatistics()["loaded-string-pools"] == 3);
+
+        // Check that the same value can still be retrieved from string pooln.
+        auto returnedEntry = cache->getStringPoolBlob(testStringPoolNodeId);
+        REQUIRE(returnedEntry.value() == serializedMessage.str());
+    }
+
+    SECTION("Create cache under a custom path") {
+        auto now = std::chrono::system_clock::now();
+        auto epoch_time = std::chrono::system_clock::to_time_t(now);
+
+        std::filesystem::path test_cache = std::filesystem::temp_directory_path() /
+            ("sqlite-unit-test-" + std::to_string(epoch_time) + ".db");
+        log().info(fmt::format("Test creating cache: {}", test_cache.string()));
+
+        // Delete cache if it already exists, e.g. from a broken test case.
+        if (std::filesystem::exists(test_cache)) {
+            std::filesystem::remove_all(test_cache);
+        }
+        REQUIRE(!std::filesystem::exists(test_cache));
+
+        // Create cache and make sure it worked.
+        auto cache = std::make_shared<mapget::SQLiteCache>(
             1024, test_cache.string(), true);
         REQUIRE(std::filesystem::exists(test_cache));
     }


### PR DESCRIPTION
... as (potential) replacement for RocksDB. Main motivation for this change are the long build times associated with rocksDB in the combination of not providing any (significant) advantages over plain usage of SQLite.