### PR TITLE
Fix GeoJsonSource tile ID datatype from U32 to U64

### DIFF
--- a/libs/geojsonsource/src/geojsonsource.cpp
+++ b/libs/geojsonsource/src/geojsonsource.cpp
@@ -56,9 +56,9 @@ auto geoJsonLayerInfo = R"json(
       "uniqueIdCompositions": [
         [
           {
-            "partId": "packedTileId",
-            "description": "NDS Packed Tile ID.",
-            "datatype": "U32"
+            "partId": "tileId",
+            "description": "Mapget Tile ID.",
+            "datatype": "U64"
           },
           {
             "partId": "featureIndex",
@@ -119,13 +119,13 @@ void GeoJsonSource::fill(const mapget::TileFeatureLayer::Ptr& tile)
         mapget::log().error("Tile not available: {}", tile->tileId().value_);
         return;
     }
-    auto packedTileId = *tileIdIt;
+    auto tileId = *tileIdIt;
 
-    // All features share the same packed tile id.
-    tile->setIdPrefix({{"packedTileId", static_cast<int64_t>(packedTileId)}});
+    // All features share the same tile id.
+    tile->setIdPrefix({{"tileId", static_cast<int64_t>(tileId)}});
 
     // Parse the GeoJSON file
-    auto path = fmt::format("{}/{}.geojson", inputDir_, std::to_string(packedTileId));
+    auto path = fmt::format("{}/{}.geojson", inputDir_, std::to_string(tileId));
 
     mapget::log().debug("Opening: {}", path);
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(test.mapget
   test-cache.cpp
   test-service-ttl.cpp
   test-config.cpp
+  test-geojsonsource.cpp
   utility.cpp
   utility.h)
 
@@ -21,6 +22,7 @@ target_link_libraries(test.mapget
     mapget-model
     mapget-http-datasource
     mapget-http-service
+    geojsonsource
     Catch2::Catch2WithMain)
 
 target_link_libraries(test.mapget.filelog

--- a/test/unit/test-geojsonsource.cpp
+++ b/test/unit/test-geojsonsource.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 
@@ -32,7 +33,15 @@ auto sampleGeoJson = R"json({"type": "FeatureCollection", "features": [{
 
 std::filesystem::path createTempGeoJsonDir()
 {
-    auto tempDir = std::filesystem::temp_directory_path() / "mapget_geojson_test";
+    // Use timestamp for unique directory name (same pattern as test-cache.cpp)
+    auto now = std::chrono::system_clock::now();
+    auto epochTime = std::chrono::system_clock::to_time_t(now);
+    auto tempDir = std::filesystem::temp_directory_path() /
+        ("mapget_geojson_test_" + std::to_string(epochTime));
+
+    if (std::filesystem::exists(tempDir)) {
+        std::filesystem::remove_all(tempDir);
+    }
     std::filesystem::create_directories(tempDir);
 
     auto geojsonPath = tempDir / (std::to_string(largeTileId) + ".geojson");

--- a/test/unit/test-geojsonsource.cpp
+++ b/test/unit/test-geojsonsource.cpp
@@ -1,0 +1,84 @@
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <fstream>
+
+#include "geojsonsource/geojsonsource.h"
+#include "mapget/model/featurelayer.h"
+
+using namespace mapget;
+
+namespace
+{
+
+// Sample GeoJSON with a 64-bit tile ID (37392110387213 > UINT32_MAX)
+constexpr uint64_t largeTileId = 37392110387213;
+
+auto sampleGeoJson = R"json({"type": "FeatureCollection", "features": [{
+    "geometry": {
+        "coordinates": [
+            [11.301851123571396, 48.04322026669979, 0.0],
+            [11.301915496587753, 48.04289236664772, 0.0],
+            [11.302142143249512, 48.04257921874523, 0.0]
+        ],
+        "type": "LineString"
+    },
+    "id": "37392110387213.10",
+    "properties": {
+        "length": 100
+    },
+    "featureIndex": 0,
+    "type": "Feature"
+}]})json";
+
+std::filesystem::path createTempGeoJsonDir()
+{
+    auto tempDir = std::filesystem::temp_directory_path() / "mapget_geojson_test";
+    std::filesystem::create_directories(tempDir);
+
+    auto geojsonPath = tempDir / (std::to_string(largeTileId) + ".geojson");
+    std::ofstream file(geojsonPath);
+    file << sampleGeoJson;
+    file.close();
+
+    return tempDir;
+}
+
+}  // namespace
+
+TEST_CASE("GeoJsonSource", "[GeoJsonSource]")
+{
+    SECTION("64-bit tile ID support")
+    {
+        // Verify our test tile ID exceeds 32-bit max
+        REQUIRE(largeTileId > UINT32_MAX);
+
+        auto tempDir = createTempGeoJsonDir();
+
+        // Create GeoJsonSource - should not throw with 64-bit tile IDs
+        geojsonsource::GeoJsonSource source(tempDir.string(), false);
+
+        // Get source info and verify coverage includes our tile
+        auto info = source.info();
+        auto layer = info.getLayer("GeoJsonAny");
+        REQUIRE(layer != nullptr);
+        REQUIRE(!layer->coverage_.empty());
+
+        // Create a TileFeatureLayer to fill
+        auto strings = std::make_shared<StringPool>(info.nodeId_);
+        auto tile = std::make_shared<TileFeatureLayer>(
+            TileId(largeTileId),
+            info.nodeId_,
+            info.mapId_,
+            layer,
+            strings);
+
+        // fill() should succeed without ID validation errors
+        REQUIRE_NOTHROW(source.fill(tile));
+
+        // Verify feature was created
+        REQUIRE(tile->numRoots() > 0);
+
+        // Cleanup
+        std::filesystem::remove_all(tempDir);
+    }
+}


### PR DESCRIPTION
Fixes #132

- Change `packedTileId` datatype from `U32` to `U64` to support 64-bit mapget tile IDs
- Rename `packedTileId` to `tileId` (removes NDS-specific terminology)
- Update description accordingly
- Add autoamted test