### PR TITLE
Enhance JSONL endpoint with tile metadata and error information

### DIFF
--- a/docs/mapget-api.md
+++ b/docs/mapget-api.md
@@ -47,6 +47,46 @@ If `Accept-Encoding: gzip` is set, the server compresses responses where possibl
 
 JSON Lines is better suited to streaming large responses than a single JSON array. Clients can start processing the first tiles immediately, do not need to buffer the complete response in memory, and can naturally consume the stream with incremental parsers.
 
+### JSONL response format
+
+Each line in the JSONL response is a GeoJSON-like FeatureCollection with additional metadata:
+
+```json
+{
+  "type": "FeatureCollection",
+  "mapgetTileId": 281479271743500,
+  "mapId": "EuropeHD",
+  "mapgetLayerId": "Roads",
+  "idPrefix": {
+    "areaId": 123,
+    "tileId": 456
+  },
+  "timestamp": "2025-01-14T10:30:00.000000Z",
+  "ttl": 3600000,
+  "error": {
+    "code": 404,
+    "message": "Error while contacting remote data source: not found"
+  },
+  "features": [...]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | string | Always `"FeatureCollection"` |
+| `mapgetTileId` | integer | The mapget tile ID (64-bit decimal) |
+| `mapId` | string | Map identifier |
+| `mapgetLayerId` | string | Layer identifier within the map |
+| `idPrefix` | object | Common ID parts shared by all features in this tile (optional) |
+| `timestamp` | string | ISO 8601 timestamp when the tile was created |
+| `ttl` | integer | Time-to-live in milliseconds (optional) |
+| `error` | object | Error information if tile creation failed (optional) |
+| `error.code` | integer | Numeric error code, e.g., HTTP status or database error (optional) |
+| `error.message` | string | Human-readable error message (optional) |
+| `features` | array | Array of GeoJSON Feature objects |
+
+The `error` object is only present if an error occurred while filling the tile. When present, the `features` array may be empty or contain partial data.
+
 ## `/abort` – cancel tile streaming
 
 `POST /abort` cancels a running `/tiles` request that was started with a matching `clientId`. It is useful when the viewport changes and the previous stream should be abandoned.

--- a/libs/model/include/mapget/model/layer.h
+++ b/libs/model/include/mapget/model/layer.h
@@ -146,6 +146,14 @@ public:
     void setError(const std::optional<std::string>& err);
 
     /**
+     * Getter and setter for 'errorCode' member variable.
+     * It's used to provide a numeric error code (e.g., HTTP status code,
+     * SQLite error code) when an error occurred while filling the tile.
+     */
+    [[nodiscard]] std::optional<int> errorCode() const;
+    void setErrorCode(const std::optional<int>& code);
+
+    /**
      * Getter and setter for 'timestamp' member variable.
      * It represents when this layer was created.
      */
@@ -191,6 +199,7 @@ protected:
     std::string mapId_;
     std::shared_ptr<LayerInfo> layerInfo_;
     std::optional<std::string> error_;
+    std::optional<int> errorCode_;
     std::chrono::time_point<std::chrono::system_clock> timestamp_;
     std::optional<std::chrono::milliseconds> ttl_;
     nlohmann::json info_;

--- a/libs/model/src/layer.cpp
+++ b/libs/model/src/layer.cpp
@@ -138,6 +138,13 @@ TileLayer::TileLayer(
         s.text1b(*error_, std::numeric_limits<uint32_t>::max());
     }
 
+    bool hasErrorCode = false;
+    s.value1b(hasErrorCode);
+    if (hasErrorCode) {
+        errorCode_ = 0;  // Tell the optional that it has a value.
+        s.value4b(*errorCode_);
+    }
+
     bool hasLegalInfo = false;
     s.value1b(hasLegalInfo);
     if (hasLegalInfo) {
@@ -207,6 +214,14 @@ void TileLayer::setError(const std::optional<std::string>& err) {
     error_ = err;
 }
 
+std::optional<int> TileLayer::errorCode() const {
+    return errorCode_;
+}
+
+void TileLayer::setErrorCode(const std::optional<int>& code) {
+    errorCode_ = code;
+}
+
 void TileLayer::setTimestamp(const std::chrono::time_point<std::chrono::system_clock>& ts) {
     timestamp_ = ts;
 }
@@ -247,6 +262,9 @@ tl::expected<void, simfil::Error> TileLayer::write(std::ostream& outputStream)
     s.value1b(error_.has_value());
     if (error_)
         s.text1b(*error_, std::numeric_limits<uint32_t>::max());
+    s.value1b(errorCode_.has_value());
+    if (errorCode_)
+        s.value4b(*errorCode_);
     s.value1b(legalInfo_.has_value());
     if (legalInfo_.has_value()) {
         s.text1b(legalInfo_.value(), std::numeric_limits<uint32_t>::max());

--- a/libs/pymapget/binding/py-layer.h
+++ b/libs/pymapget/binding/py-layer.h
@@ -52,6 +52,21 @@ void bindTileLayer(py::module_& m)
             Set the error occurred while the tile was filled.
             )pbdoc")
         .def(
+            "error_code",
+            [](TileFeatureLayer const& self) { return self.errorCode(); },
+            R"pbdoc(
+            Get the error code (e.g., HTTP status code, SQLite error code)
+            if an error occurred while the tile was filled.
+            )pbdoc")
+        .def(
+            "set_error_code",
+            [](TileFeatureLayer& self, int code) { self.setErrorCode(code); },
+            py::arg("code"),
+            R"pbdoc(
+            Set the error code (e.g., HTTP status code, SQLite error code)
+            for an error that occurred while the tile was filled.
+            )pbdoc")
+        .def(
             "timestamp",
             [](TileFeatureLayer const& self) {return self.timestamp(); },
             R"pbdoc(


### PR DESCRIPTION
Closes #135

Enhance the JSONL response format for the `/tiles` endpoint to include tile-level metadata for better automated processing.

## Changes
- Add `errorCode` field to `TileLayer` for numeric error codes (HTTP status, SQLite codes, etc.)
- Enhance `TileFeatureLayer::toJson()` to include:
  - `mapgetTileId` - decimal uint64 tile ID
  - `mapgetLayerId` - layer identifier
  - `mapId` - map identifier
  - `idPrefix` - common ID parts shared by all features
  - `timestamp` - ISO 8601 format
  - `ttl` - time-to-live in milliseconds
  - `error` object with `code` and `message`
- Update Python bindings with `error_code`/`set_error_code`
- Document new response format in `mapget-api.md`
- Add unit tests

## Test Plan
- [x] Unit tests pass
- [ ] Manual verification of JSONL output