### PR TITLE
Add optional mapId config for GeoJsonFolder

### DIFF
--- a/libs/http-service/src/cli.cpp
+++ b/libs/http-service/src/cli.cpp
@@ -92,6 +92,11 @@ nlohmann::json geoJsonFolderSchema()
                 {"title", "Folder"},
                 {"description", "Path to a folder containing GeoJSON tiles."}
             }},
+            {"mapId", {
+                {"type", "string"},
+                {"title", "Map ID"},
+                {"description", "Custom map identifier. If not provided, derived from folder path."}
+            }},
             {"withAttrLayers", {
                 {"type", "boolean"},
                 {"title", "With Attribute Layers"},
@@ -238,7 +243,10 @@ void registerDefaultDatasourceTypes() {
                 bool withAttributeLayers = true;
                 if (auto withAttributeLayersNode = config["withAttrLayers"])
                     withAttributeLayers = withAttributeLayersNode.as<bool>();
-                return std::make_shared<geojsonsource::GeoJsonSource>(folder.as<std::string>(), withAttributeLayers);
+                std::string mapId;
+                if (auto mapIdNode = config["mapId"])
+                    mapId = mapIdNode.as<std::string>();
+                return std::make_shared<geojsonsource::GeoJsonSource>(folder.as<std::string>(), withAttributeLayers, mapId);
             }
             throw std::runtime_error("Missing `folder` field.");
         },


### PR DESCRIPTION
Add optional `mapId` property to GeoJsonFolder config, allowing users to set a custom map identifier instead of relying on automatic derivation from the folder path.

- Add `mapId` to the JSON schema for GeoJsonFolder
- Pass `mapId` to GeoJsonSource constructor (falls back to path-derived ID if not provided)

Closes #142