### PR TITLE
Release 2026.1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(mapget LANGUAGES CXX C)
 # Allow version to be set from command line for CI/CD
 # For local development, use the default version
 if(NOT DEFINED MAPGET_VERSION)
-  set(MAPGET_VERSION 2026.1.0)
+  set(MAPGET_VERSION 2026.1.3)
 endif()
 
 set(CMAKE_CXX_STANDARD 20)

--- a/docs/mapget-api.md
+++ b/docs/mapget-api.md
@@ -69,7 +69,7 @@ To cancel, either send a new request message on the same connection (which repla
 - **Query parameters:**
   - `clientId` (required): numeric client id received via the websocket `RequestContext` frame.
   - `waitMs` (optional): long-poll timeout in milliseconds. Defaults to 25000 and is clamped to 30000.
-  - `maxBytes` (optional): batch size budget. If greater than zero, the response may concatenate multiple VTLV frames up to that byte budget (capped at 5 MiB).
+  - `maxBytes` (optional): batch size budget. If greater than zero, the response may concatenate multiple VTLV frames up to that byte budget (capped at 64 MiB; the budget is counted before optional gzip compression).
   - `compress` (optional): set to `1` to enable gzip compression when the client also sends `Accept-Encoding: gzip`.
 - **Response:**
   - `200 application/octet-stream` with one or more concatenated `TileLayerStream` VTLV frames.

--- a/docs/mapget-api.md
+++ b/docs/mapget-api.md
@@ -34,6 +34,7 @@ Each item contains map ID, available layers and basic metadata. Each layer entry
     - `layerId`: string, ID of the layer within that map.
     - either `tileIds`: array of numeric tile IDs in mapget’s tiling scheme. This is an **unstaged** request shape: the service does not expand it into one backend fetch per advertised stage and returns one tile response per requested tile with no explicit stage affinity.
     - or `tileIdsByNextStage`: array of arrays where bucket `i` lists tiles whose next missing stage is `i`. This is the **staged** request shape: the service expands each tile to stage `i` and all higher stages advertised by the layer.
+    - `priorityTileIds` (optional): array of numeric tile IDs from the same request that should be scheduled before regular tile IDs. This is only a scheduling hint; it does not request additional tiles and does not change staged vs. unstaged semantics.
   - `stringPoolOffsets` (optional): dictionary from datasource node ID to last known string ID. Used by advanced clients to avoid receiving the same field names repeatedly in the binary stream.
 - **Response:**
   - `application/jsonl` if `Accept: application/jsonl` is sent.
@@ -42,6 +43,26 @@ Each item contains map ID, available layers and basic metadata. Each layer entry
 Tiles are streamed as they become available. In JSONL mode, each line is the JSON representation of one tile layer. In binary mode, the response is a sequence of versioned messages that can be decoded using the tile stream protocol from `mapget-model.md`.
 
 For staged feature-layer clients, `tileIdsByNextStage` must be used even when only bucket `0` is non-empty. Collapsing such a request to plain `tileIds` changes its semantics to an unstaged request.
+
+`priorityTileIds` is intended for interactive clients that need a few foreground tiles to finish before broad background loading. For example, a map viewer can prioritize the selected feature's tile so its high-stage inspection data arrives before unrelated viewport tiles. The server may still finish already-running jobs first.
+
+Example staged request with one foreground tile:
+
+```json
+{
+  "requests": [
+    {
+      "mapId": "Tropico",
+      "layerId": "WayLayer",
+      "tileIdsByNextStage": [
+        [1234, 5678],
+        [9112]
+      ],
+      "priorityTileIds": [9112]
+    }
+  ]
+}
+```
 
 If `Accept-Encoding: gzip` is set, the server compresses responses where possible, which is especially useful for JSONL streams.
 

--- a/docs/mapget-dev-guide.md
+++ b/docs/mapget-dev-guide.md
@@ -137,6 +137,24 @@ Internally the service maintains a shared controller object and a pool of worker
 
 Jobs are keyed by `MapTileKey` so that concurrent requests for the same tile can take advantage of a single in‑progress computation. Once a tile finishes, waiting requests can receive the cached result instead of triggering duplicate work.
 
+### Staged request scheduling
+
+`LayerTilesRequest` supports two request shapes:
+
+- `tileIds` creates an unstaged request. The service asks the datasource for one tile per ID using `UnspecifiedStage`.
+- `tileIdsByNextStage` creates a staged request. Bucket `N` means “this tile has stages below `N`; request stage `N` and all higher stages advertised by the layer”.
+
+For staged requests, `prepareResolvedLayer(...)` expands logical tile IDs into concrete `MapTileKey`s in stage-major order. The service then schedules those keys through the shared controller. The controller rotates requests after each consumed candidate, so multiple active requests share datasource workers instead of one large request monopolizing the queue.
+
+Interactive frontends can add `priorityTileIds` to either request shape. This is a scheduling hint only:
+
+- it does not add tile IDs to the request,
+- it does not change staged vs. unstaged semantics,
+- it does not preempt jobs that are already running,
+- it only moves matching tile IDs to the front of that request’s resolved scheduling order.
+
+The intended use case is feature inspection: a selected tile may need a high-stage payload for full attributes while many background viewport tiles still need low-stage payloads. `priorityTileIds` lets the selected tile finish first without globally changing the low-fi-first behavior for normal map loading.
+
 ### Service-level sequence
 
 The following sequence diagram summarises what happens when a client requests tiles through the HTTP service:
@@ -209,7 +227,7 @@ For interactive clients, tile streaming uses WebSocket `GET /tiles` as a control
 
 For `/tiles`, the HTTP layer:
 
-- parses the JSON body to extract `requests` (`tileIds` or stage-aware `tileIdsByNextStage`) and optional `stringPoolOffsets`,
+- parses the JSON body to extract `requests` (`tileIds` or stage-aware `tileIdsByNextStage`), optional `priorityTileIds`, and optional `stringPoolOffsets`,
 - constructs one `LayerTilesRequest` per map–layer combination,
 - attaches callbacks that feed results into a shared `HttpTilesRequestState`, and
 - sends out each tile as soon as it is produced by the service.
@@ -217,6 +235,15 @@ For `/tiles`, the HTTP layer:
 In JSONL mode the response is a sequence of newline‑separated JSON objects. In binary mode the HTTP layer uses `TileLayerStream::Writer` to serialize string pool updates and tile blobs. Binary responses can optionally be compressed using gzip if the client sends `Accept-Encoding: gzip`.
 
 WebSocket `/tiles` uses the same request JSON shape but serves only as the control plane: it emits `RequestContext` and `Status` VTLV frames, while `/tiles/next` performs the long-poll delivery of one or more binary tile frames (optionally batched up to `maxBytes`).
+
+The WebSocket path also keeps queue-level priority metadata:
+
+- `expandLayerTilesRequestKeys(...)` expands staged requests in the same order as `LayerTilesRequest`.
+- The session records a priority rank for each desired `MapTileKey`.
+- Completed tile frames are inserted into the outgoing queue by that rank, with string-pool updates kept ahead of tile data.
+- When a replacement request arrives, queued frames outside the new desired tile set are dropped and the remaining frames are reprioritized.
+
+This means `priorityTileIds` affects both backend scheduling and already-produced outgoing frames, while still preserving request replacement semantics.
 
 ### Configuration endpoints
 

--- a/libs/http-datasource/src/http-server.cpp
+++ b/libs/http-datasource/src/http-server.cpp
@@ -153,6 +153,12 @@ void HttpServer::go(std::string const& interfaceAddr, uint16_t port, uint32_t wa
                 // Allow derived class to set up the server.
                 setup(app);
 
+                // Raise Drogon's default WebSocket client message size limit
+                // (128 KB) to 10 MB. Large tile requests with many tile IDs
+                // can exceed the default and trigger connection shutdown,
+                // cascading into a crash (std::terminate).
+                app.setClientMaxWebSocketMessageSize(10 * 1024 * 1024);
+
                 app.addListener(interfaceAddr, port);
 
                 app.registerBeginningAdvice([this]() {

--- a/libs/http-service/src/tiles-http-handler.cpp
+++ b/libs/http-service/src/tiles-http-handler.cpp
@@ -123,7 +123,8 @@ struct HttpService::Impl::TilesStreamState : std::enable_shared_from_this<TilesS
             requests_.push_back(std::make_shared<LayerTilesRequest>(
                 std::move(parsed.mapId),
                 std::move(parsed.layerId),
-                std::move(parsed.tileIdsByNextStage)));
+                std::move(parsed.tileIdsByNextStage),
+                std::move(parsed.priorityTileIds)));
         } else {
             auto tileIds = parsed.tileIdsByNextStage.empty()
                 ? std::vector<TileId>{}
@@ -131,7 +132,8 @@ struct HttpService::Impl::TilesStreamState : std::enable_shared_from_this<TilesS
             requests_.push_back(std::make_shared<LayerTilesRequest>(
                 std::move(parsed.mapId),
                 std::move(parsed.layerId),
-                std::move(tileIds)));
+                std::move(tileIds),
+                std::move(parsed.priorityTileIds)));
         }
     }
 

--- a/libs/http-service/src/tiles-request-json.cpp
+++ b/libs/http-service/src/tiles-request-json.cpp
@@ -1,6 +1,7 @@
 #include "tiles-request-json.h"
 
 #include <algorithm>
+#include <optional>
 #include <set>
 #include <stdexcept>
 
@@ -12,6 +13,18 @@ ParsedLayerTilesRequest parseLayerTilesRequestJson(const nlohmann::json& request
     ParsedLayerTilesRequest result;
     result.mapId = requestJson.at("mapId").get<std::string>();
     result.layerId = requestJson.at("layerId").get<std::string>();
+
+    if (auto priorityIt = requestJson.find("priorityTileIds");
+        priorityIt != requestJson.end())
+    {
+        if (!priorityIt->is_array()) {
+            throw std::runtime_error("priorityTileIds must be an array");
+        }
+        result.priorityTileIds.reserve(priorityIt->size());
+        for (auto const& tileIdJson : *priorityIt) {
+            result.priorityTileIds.emplace_back(tileIdJson.get<uint64_t>());
+        }
+    }
 
     if (auto stagedIt = requestJson.find("tileIdsByNextStage");
         stagedIt != requestJson.end())
@@ -56,10 +69,22 @@ std::vector<MapTileKey> expandLayerTilesRequestKeys(
 {
     std::vector<MapTileKey> result;
     std::set<MapTileKey> seen;
+    const std::set<TileId> priorityTileIds(
+        request.priorityTileIds.begin(),
+        request.priorityTileIds.end());
+    const auto isPriorityTile = [&priorityTileIds](TileId const& tileId) {
+        return priorityTileIds.find(tileId) != priorityTileIds.end();
+    };
 
     if (!request.usesStageBuckets) {
-        if (!request.tileIdsByNextStage.empty()) {
+        const auto appendUnstagedTiles = [&](std::optional<bool> priorityFilter) {
+            if (request.tileIdsByNextStage.empty()) {
+                return;
+            }
             for (auto const& tileId : request.tileIdsByNextStage.front()) {
+                if (priorityFilter && isPriorityTile(tileId) != *priorityFilter) {
+                    continue;
+                }
                 MapTileKey key(
                     layerType,
                     request.mapId,
@@ -70,24 +95,43 @@ std::vector<MapTileKey> expandLayerTilesRequestKeys(
                     result.push_back(std::move(key));
                 }
             }
+        };
+
+        if (priorityTileIds.empty()) {
+            appendUnstagedTiles(std::nullopt);
+        } else {
+            appendUnstagedTiles(true);
+            appendUnstagedTiles(false);
         }
         return result;
     }
 
     auto const normalizedStageCount = std::max<uint32_t>(1U, stageCount);
-    for (uint32_t stage = 0; stage < normalizedStageCount; ++stage) {
-        for (size_t bucketIndex = 0; bucketIndex < request.tileIdsByNextStage.size(); ++bucketIndex) {
-            auto const nextMissingStage = static_cast<uint32_t>(bucketIndex);
-            if (nextMissingStage > stage || nextMissingStage >= normalizedStageCount) {
-                continue;
-            }
-            for (auto const& tileId : request.tileIdsByNextStage[bucketIndex]) {
-                MapTileKey key(layerType, request.mapId, request.layerId, tileId, stage);
-                if (seen.insert(key).second) {
-                    result.push_back(std::move(key));
+    const auto appendStagedTiles = [&](std::optional<bool> priorityFilter) {
+        for (uint32_t stage = 0; stage < normalizedStageCount; ++stage) {
+            for (size_t bucketIndex = 0; bucketIndex < request.tileIdsByNextStage.size(); ++bucketIndex) {
+                auto const nextMissingStage = static_cast<uint32_t>(bucketIndex);
+                if (nextMissingStage > stage || nextMissingStage >= normalizedStageCount) {
+                    continue;
+                }
+                for (auto const& tileId : request.tileIdsByNextStage[bucketIndex]) {
+                    if (priorityFilter && isPriorityTile(tileId) != *priorityFilter) {
+                        continue;
+                    }
+                    MapTileKey key(layerType, request.mapId, request.layerId, tileId, stage);
+                    if (seen.insert(key).second) {
+                        result.push_back(std::move(key));
+                    }
                 }
             }
         }
+    };
+
+    if (priorityTileIds.empty()) {
+        appendStagedTiles(std::nullopt);
+    } else {
+        appendStagedTiles(true);
+        appendStagedTiles(false);
     }
 
     return result;

--- a/libs/http-service/src/tiles-request-json.h
+++ b/libs/http-service/src/tiles-request-json.h
@@ -15,6 +15,7 @@ struct ParsedLayerTilesRequest
     std::string mapId;
     std::string layerId;
     std::vector<std::vector<TileId>> tileIdsByNextStage;
+    std::vector<TileId> priorityTileIds;
     bool usesStageBuckets = false;
 };
 

--- a/libs/http-service/src/tiles-ws-controller.cpp
+++ b/libs/http-service/src/tiles-ws-controller.cpp
@@ -710,12 +710,14 @@ public:
                 request = std::make_shared<LayerTilesRequest>(
                     parsed.request.mapId,
                     parsed.request.layerId,
-                    std::move(tileIdsByNextStageToFetch));
+                    std::move(tileIdsByNextStageToFetch),
+                    parsed.request.priorityTileIds);
             } else {
                 request = std::make_shared<LayerTilesRequest>(
                     parsed.request.mapId,
                     parsed.request.layerId,
-                    std::move(unstagedTileIdsToFetch));
+                    std::move(unstagedTileIdsToFetch),
+                    parsed.request.priorityTileIds);
             }
             serviceRequests.push_back(request);
             nextActiveRequests.push_back(request);

--- a/libs/http-service/src/tiles-ws-controller.cpp
+++ b/libs/http-service/src/tiles-ws-controller.cpp
@@ -69,7 +69,7 @@ std::atomic<int64_t> gNextClientId{1};
 
 constexpr int64_t DEFAULT_PULL_WAIT_MS = 25000;
 constexpr int64_t MAX_PULL_WAIT_MS = 30000;
-constexpr int64_t MAX_PULL_BATCH_BYTES = 5 * 1024 * 1024;
+constexpr int64_t MAX_PULL_BATCH_BYTES = 64 * 1024 * 1024;
 constexpr LayerType REQUEST_TILE_LAYER_TYPE = LayerType::Features;
 constexpr int64_t LOWEST_TILE_PRIORITY = std::numeric_limits<int64_t>::max();
 constexpr bool EMIT_LOAD_STATE_FRAMES = false;
@@ -1723,6 +1723,7 @@ void handleTilesNextRequest(
                 resp->setContentTypeCode(drogon::CT_APPLICATION_OCTET_STREAM);
                 if (enableGzip) {
                     if (auto compressed = gzipCompress(result.frameBytes)) {
+                        resp->addHeader("x-mapget-compressed-bytes", std::to_string(compressed->size()));
                         resp->setBody(std::move(*compressed));
                         resp->addHeader("Content-Encoding", "gzip");
                         resp->addHeader("Vary", "Accept-Encoding");

--- a/libs/http-service/src/tiles-ws-controller.cpp
+++ b/libs/http-service/src/tiles-ws-controller.cpp
@@ -1095,61 +1095,68 @@ private:
             return;
         if (!layer)
             return;
-        std::optional<std::pair<std::string, simfil::StringId>> stringPoolCommit;
-        std::vector<PullDispatch> pullDispatches;
 
-        {
-            std::lock_guard lock(mutex_);
-            if (cancelled_)
-                return;
-            auto requestedTileKey = matchDesiredTileKeyLocked(
-                layer->id(),
-                layer->layerInfo() ? std::max<uint32_t>(1U, layer->layerInfo()->stages_) : 1U);
-            // Late-arriving tile for an outdated request: drop before serialization work.
-            if (!requestedTileKey.has_value()) {
-                return;
-            }
+        try {
+            std::optional<std::pair<std::string, simfil::StringId>> stringPoolCommit;
+            std::vector<PullDispatch> pullDispatches;
 
-            if (currentWriteBatch_.has_value()) {
-                raise("TilesWsSession writer callback re-entered");
-            }
-            currentWriteBatch_.emplace();
-            writer_->write(layer);
-            auto batch = std::move(*currentWriteBatch_);
-            currentWriteBatch_.reset();
+            {
+                std::lock_guard lock(mutex_);
+                if (cancelled_)
+                    return;
+                auto requestedTileKey = matchDesiredTileKeyLocked(
+                    layer->id(),
+                    layer->layerInfo() ? std::max<uint32_t>(1U, layer->layerInfo()->stages_) : 1U);
+                // Late-arriving tile for an outdated request: drop before serialization work.
+                if (!requestedTileKey.has_value()) {
+                    return;
+                }
 
-            // If a StringPool message was generated, the writer updates writerOffsets_
-            // to the new highest string ID for this node after emitting it.
-            const auto nodeId = layer->nodeId();
-            const auto it = writerOffsets_.find(nodeId);
-            if (it != writerOffsets_.end()) {
-                const auto newOffset = it->second;
-                for (auto const& m : batch) {
-                    if (m.type == TileLayerStream::MessageType::StringPool) {
-                        stringPoolCommit = std::make_pair(nodeId, newOffset);
-                        break;
+                if (currentWriteBatch_.has_value()) {
+                    raise("TilesWsSession writer callback re-entered");
+                }
+                currentWriteBatch_.emplace();
+                writer_->write(layer);
+                auto batch = std::move(*currentWriteBatch_);
+                currentWriteBatch_.reset();
+
+                // If a StringPool message was generated, the writer updates writerOffsets_
+                // to the new highest string ID for this node after emitting it.
+                const auto nodeId = layer->nodeId();
+                const auto it = writerOffsets_.find(nodeId);
+                if (it != writerOffsets_.end()) {
+                    const auto newOffset = it->second;
+                    for (auto const& m : batch) {
+                        if (m.type == TileLayerStream::MessageType::StringPool) {
+                            stringPoolCommit = std::make_pair(nodeId, newOffset);
+                            break;
+                        }
                     }
                 }
-            }
 
-            for (auto& m : batch) {
-                OutgoingFrame frame;
-                frame.bytes = std::move(m.bytes);
-                frame.type = m.type;
-                if (m.type == TileLayerStream::MessageType::StringPool) {
-                    frame.stringPoolCommit = stringPoolCommit;
-                    frame.requestedTileKey = *requestedTileKey;
+                for (auto& m : batch) {
+                    OutgoingFrame frame;
+                    frame.bytes = std::move(m.bytes);
+                    frame.type = m.type;
+                    if (m.type == TileLayerStream::MessageType::StringPool) {
+                        frame.stringPoolCommit = stringPoolCommit;
+                        frame.requestedTileKey = *requestedTileKey;
+                    }
+                    if (m.type == TileLayerStream::MessageType::TileFeatureLayer
+                        || m.type == TileLayerStream::MessageType::TileSourceDataLayer) {
+                        frame.requestedTileKey = *requestedTileKey;
+                    }
+                    enqueueOutgoingLocked(std::move(frame));
                 }
-                if (m.type == TileLayerStream::MessageType::TileFeatureLayer
-                    || m.type == TileLayerStream::MessageType::TileSourceDataLayer) {
-                    frame.requestedTileKey = *requestedTileKey;
-                }
-                enqueueOutgoingLocked(std::move(frame));
+                // Newly queued frames can immediately satisfy blocked pull waiters.
+                drainReadyPullWaitersLocked(pullDispatches);
             }
-            // Newly queued frames can immediately satisfy blocked pull waiters.
-            drainReadyPullWaitersLocked(pullDispatches);
+            dispatchPullResults(std::move(pullDispatches));
         }
-        dispatchPullResults(std::move(pullDispatches));
+        catch (const std::exception& e) {
+            log().error("Failed to stream tile layer: {}", e.what());
+            cancelNoStatus();
+        }
     }
 
     /// Update per-request completion state and emit status when it changes.
@@ -1197,7 +1204,15 @@ private:
             cancelNoStatus();
             return;
         }
-        conn->send(encodeStreamMessage(type, payload), drogon::WebSocketMessageType::Binary);
+        try {
+            conn->send(
+                encodeStreamMessage(type, payload),
+                drogon::WebSocketMessageType::Binary);
+        }
+        catch (const std::exception& e) {
+            log().warn("WebSocket send failed: {}", e.what());
+            cancelNoStatus();
+        }
     }
 
     /// Send a status frame describing the current request statuses.
@@ -1339,66 +1354,73 @@ public:
     }
 
     /// Handle control and request messages from the websocket client.
+    /// Wrapped in try-catch because Drogon calls this with no exception
+    /// protection — an uncaught exception would terminate the process.
     void handleNewMessage(
         const drogon::WebSocketConnectionPtr& conn,
         std::string&& message,
         const drogon::WebSocketMessageType& type) override
     {
-        auto session = conn->getContext<TilesWsSession>();
-        if (!session) {
-            // This is a defensive fallback for unexpected context loss.
-            session = std::make_shared<TilesWsSession>(service_, conn, AuthHeaders{});
-            session->registerForMetrics();
-            {
-                std::lock_guard lock(gSessionRegistryMutex);
-                gSessionRegistry[session->clientId()] = session;
-            }
-            conn->setContext(session);
-        }
-
-        if (type != drogon::WebSocketMessageType::Text) {
-            const auto payload = nlohmann::json::object({
-                {"type", "mapget.tiles.status"},
-                {"allDone", true},
-                {"requests", nlohmann::json::array()},
-                {"message", "Expected a text message containing JSON."},
-            }).dump();
-            conn->send(encodeStreamMessage(TileLayerStream::MessageType::Status, payload), drogon::WebSocketMessageType::Binary);
-            return;
-        }
-
-        nlohmann::json j;
         try {
-            j = nlohmann::json::parse(message);
-        }
-        catch (const std::exception& e) {
-            const auto payload = nlohmann::json::object({
-                {"type", "mapget.tiles.status"},
-                {"allDone", true},
-                {"requests", nlohmann::json::array()},
-                {"message", fmt::format("Invalid JSON: {}", e.what())},
-            }).dump();
-            conn->send(encodeStreamMessage(TileLayerStream::MessageType::Status, payload), drogon::WebSocketMessageType::Binary);
-            return;
-        }
+            auto session = conn->getContext<TilesWsSession>();
+            if (!session) {
+                // This is a defensive fallback for unexpected context loss.
+                session = std::make_shared<TilesWsSession>(service_, conn, AuthHeaders{});
+                session->registerForMetrics();
+                {
+                    std::lock_guard lock(gSessionRegistryMutex);
+                    gSessionRegistry[session->clientId()] = session;
+                }
+                conn->setContext(session);
+            }
 
-        // Patch per-connection string pool offsets if supplied.
-        if (j.contains("stringPoolOffsets")) {
-            std::string errorMessage;
-            if (!session->applyStringPoolOffsetsPatch(j["stringPoolOffsets"], errorMessage)) {
+            if (type != drogon::WebSocketMessageType::Text) {
                 const auto payload = nlohmann::json::object({
                     {"type", "mapget.tiles.status"},
                     {"allDone", true},
                     {"requests", nlohmann::json::array()},
-                    {"message", std::move(errorMessage)},
+                    {"message", "Expected a text message containing JSON."},
                 }).dump();
                 conn->send(encodeStreamMessage(TileLayerStream::MessageType::Status, payload), drogon::WebSocketMessageType::Binary);
                 return;
             }
-        }
 
-        const auto requestId = session->allocateRequestId(j);
-        session->updateFromClientRequest(j, requestId);
+            nlohmann::json j;
+            try {
+                j = nlohmann::json::parse(message);
+            }
+            catch (const std::exception& e) {
+                const auto payload = nlohmann::json::object({
+                    {"type", "mapget.tiles.status"},
+                    {"allDone", true},
+                    {"requests", nlohmann::json::array()},
+                    {"message", fmt::format("Invalid JSON: {}", e.what())},
+                }).dump();
+                conn->send(encodeStreamMessage(TileLayerStream::MessageType::Status, payload), drogon::WebSocketMessageType::Binary);
+                return;
+            }
+
+            // Patch per-connection string pool offsets if supplied.
+            if (j.contains("stringPoolOffsets")) {
+                std::string errorMessage;
+                if (!session->applyStringPoolOffsetsPatch(j["stringPoolOffsets"], errorMessage)) {
+                    const auto payload = nlohmann::json::object({
+                        {"type", "mapget.tiles.status"},
+                        {"allDone", true},
+                        {"requests", nlohmann::json::array()},
+                        {"message", std::move(errorMessage)},
+                    }).dump();
+                    conn->send(encodeStreamMessage(TileLayerStream::MessageType::Status, payload), drogon::WebSocketMessageType::Binary);
+                    return;
+                }
+            }
+
+            const auto requestId = session->allocateRequestId(j);
+            session->updateFromClientRequest(j, requestId);
+        }
+        catch (const std::exception& e) {
+            log().error("WebSocket message handler failed: {}", e.what());
+        }
     }
 
     /// Abort outstanding backend work once the websocket is closed.

--- a/libs/http-service/src/tiles-ws-controller.cpp
+++ b/libs/http-service/src/tiles-ws-controller.cpp
@@ -74,6 +74,19 @@ constexpr LayerType REQUEST_TILE_LAYER_TYPE = LayerType::Features;
 constexpr int64_t LOWEST_TILE_PRIORITY = std::numeric_limits<int64_t>::max();
 constexpr bool EMIT_LOAD_STATE_FRAMES = false;
 
+struct ClientRequestChunk
+{
+    bool chunked = false;
+    uint64_t index = 0;
+    bool isLast = true;
+};
+
+enum class ClientRequestUpdateMode
+{
+    Replace,
+    Append,
+};
+
 /// Clamp an atomic metric value to zero to avoid exposing negative snapshots.
 [[nodiscard]] int64_t nonNegative(std::atomic<int64_t> const& value)
 {
@@ -204,6 +217,37 @@ constexpr bool EMIT_LOAD_STATE_FRAMES = false;
         return std::max<int64_t>(0, raw);
     }
     return 0;
+}
+
+[[nodiscard]] ClientRequestChunk parseClientRequestChunk(const nlohmann::json& j)
+{
+    auto chunkIt = j.find("chunk");
+    if (chunkIt == j.end()) {
+        return {};
+    }
+    if (!chunkIt->is_object()) {
+        throw std::runtime_error("chunk must be an object");
+    }
+
+    auto indexIt = chunkIt->find("index");
+    if (indexIt == chunkIt->end()
+        || !(indexIt->is_number_integer() || indexIt->is_number_unsigned())) {
+        throw std::runtime_error("chunk.index must be a non-negative integer");
+    }
+    if (indexIt->is_number_integer() && indexIt->get<int64_t>() < 0) {
+        throw std::runtime_error("chunk.index must be a non-negative integer");
+    }
+
+    auto isLastIt = chunkIt->find("isLast");
+    if (isLastIt == chunkIt->end() || !isLastIt->is_boolean()) {
+        throw std::runtime_error("chunk.isLast must be a boolean");
+    }
+
+    return ClientRequestChunk{
+        .chunked = true,
+        .index = static_cast<uint64_t>(parseNonNegativeInt64(*chunkIt, "index")),
+        .isLast = isLastIt->get<bool>(),
+    };
 }
 
 /// Build a canonical request key using map/layer/tile while normalizing layer type.
@@ -400,8 +444,108 @@ public:
         return requestId;
     }
 
+    /// Parse a possibly chunked request message and apply each chunk immediately.
+    void updateFromClientRequestMessage(const nlohmann::json& j, uint64_t requestId)
+    {
+        ClientRequestChunk chunk;
+        try {
+            chunk = parseClientRequestChunk(j);
+        }
+        catch (const std::exception& e) {
+            rejectClientRequest(requestId, fmt::format("Invalid request chunk: {}", e.what()));
+            return;
+        }
+
+        if (!chunk.chunked) {
+            {
+                std::lock_guard lock(mutex_);
+                pendingChunkedRequestId_ = 0;
+                pendingChunkedNextIndex_ = 0;
+                requestChunksComplete_ = true;
+            }
+            updateFromClientRequest(
+                j,
+                requestId,
+                ClientRequestUpdateMode::Replace,
+                true);
+            return;
+        }
+
+        auto updateMode = ClientRequestUpdateMode::Replace;
+        std::optional<std::string> errorMessage;
+        {
+            std::lock_guard lock(mutex_);
+            auto requestsIt = j.find("requests");
+            if (requestsIt == j.end() || !requestsIt->is_array()) {
+                pendingChunkedRequestId_ = 0;
+                pendingChunkedNextIndex_ = 0;
+                requestChunksComplete_ = true;
+                errorMessage = "Missing or invalid 'requests' array in chunk.";
+            } else if (chunk.index == 0) {
+                updateMode = ClientRequestUpdateMode::Replace;
+                if (chunk.isLast) {
+                    pendingChunkedRequestId_ = 0;
+                    pendingChunkedNextIndex_ = 0;
+                    requestChunksComplete_ = true;
+                } else {
+                    pendingChunkedRequestId_ = requestId;
+                    pendingChunkedNextIndex_ = 1;
+                    requestChunksComplete_ = false;
+                }
+            } else if (pendingChunkedRequestId_ != requestId || pendingChunkedNextIndex_ != chunk.index) {
+                const auto expectedRequestId = pendingChunkedRequestId_;
+                const auto expectedChunkIndex = pendingChunkedNextIndex_;
+                pendingChunkedRequestId_ = 0;
+                pendingChunkedNextIndex_ = 0;
+                requestChunksComplete_ = true;
+                errorMessage = fmt::format(
+                    "Invalid request chunk sequence: expected chunk {} for request {}, got chunk {} for request {}.",
+                    expectedChunkIndex,
+                    expectedRequestId,
+                    chunk.index,
+                    requestId);
+            } else {
+                updateMode = ClientRequestUpdateMode::Append;
+                if (chunk.isLast) {
+                    pendingChunkedRequestId_ = 0;
+                    pendingChunkedNextIndex_ = 0;
+                    requestChunksComplete_ = true;
+                } else {
+                    pendingChunkedNextIndex_ = chunk.index + 1;
+                    requestChunksComplete_ = false;
+                }
+            }
+        }
+
+        if (errorMessage) {
+            rejectClientRequest(requestId, std::move(*errorMessage));
+            return;
+        }
+        updateFromClientRequest(j, requestId, updateMode, chunk.isLast);
+    }
+
+    void rejectClientRequest(uint64_t requestId, std::string message)
+    {
+        {
+            std::lock_guard lock(mutex_);
+            requestId_ = requestId;
+            requestInfos_.clear();
+            requestStatuses_.clear();
+            pendingChunkedRequestId_ = 0;
+            pendingChunkedNextIndex_ = 0;
+            requestChunksComplete_ = true;
+            statusEmissionEnabled_ = true;
+        }
+        queueRequestContextMessage();
+        queueStatusMessage(std::move(message));
+    }
+
     /// Parse and apply a full logical tile request update from the client.
-    void updateFromClientRequest(const nlohmann::json& j, uint64_t requestId)
+    void updateFromClientRequest(
+        const nlohmann::json& j,
+        uint64_t requestId,
+        ClientRequestUpdateMode updateMode,
+        bool requestChunksComplete)
     {
         auto requestsIt = j.find("requests");
         if (requestsIt == j.end() || !requestsIt->is_array()) {
@@ -411,6 +555,9 @@ public:
                 requestId_ = requestId;
                 requestInfos_.clear();
                 requestStatuses_.clear();
+                pendingChunkedRequestId_ = 0;
+                pendingChunkedNextIndex_ = 0;
+                requestChunksComplete_ = true;
                 statusEmissionEnabled_ = true;
             }
             queueRequestContextMessage();
@@ -463,6 +610,9 @@ public:
                 requestId_ = requestId;
                 requestInfos_.clear();
                 requestStatuses_.clear();
+                pendingChunkedRequestId_ = 0;
+                pendingChunkedNextIndex_ = 0;
+                requestChunksComplete_ = true;
                 statusEmissionEnabled_ = true;
             }
             queueRequestContextMessage();
@@ -475,6 +625,23 @@ public:
         std::vector<RequestStatus> nextRequestStatuses(parsedRequests.size(), RequestStatus::Success);
         std::vector<RequestInfo> nextRequestInfos;
         nextRequestInfos.reserve(parsedRequests.size());
+        size_t requestIndexBase = 0;
+        std::optional<std::string> appendError;
+        if (updateMode == ClientRequestUpdateMode::Append) {
+            std::lock_guard lock(mutex_);
+            if (requestId_ != requestId) {
+                appendError = fmt::format(
+                    "Cannot append request chunk {} to active request {}.",
+                    requestId,
+                    requestId_);
+            } else {
+                requestIndexBase = requestInfos_.size();
+            }
+        }
+        if (appendError) {
+            rejectClientRequest(requestId, std::move(*appendError));
+            return;
+        }
 
         for (size_t index = 0; index < parsedRequests.size(); ++index) {
             auto& parsed = parsedRequests[index];
@@ -556,6 +723,7 @@ public:
 
             const auto weak = weak_from_this();
             const auto expectedRequestId = requestId;
+            const auto statusIndex = requestIndexBase + index;
             request->onFeatureLayer([weak](auto&& layer) {
                 if (auto self = weak.lock()) {
                     self->onTileLayer(std::forward<decltype(layer)>(layer));
@@ -573,9 +741,9 @@ public:
                     }
                 });
             }
-            request->onDone_ = [weak, index, expectedRequestId, request](RequestStatus status) {
+            request->onDone_ = [weak, statusIndex, expectedRequestId, request](RequestStatus status) {
                 if (auto self = weak.lock()) {
-                    self->onRequestDone(index, expectedRequestId, request, status);
+                    self->onRequestDone(statusIndex, expectedRequestId, request, status);
                 }
             };
         }
@@ -583,15 +751,32 @@ public:
         std::vector<LayerTilesRequest::Ptr> replacedRequests;
         {
             std::lock_guard lock(mutex_);
-            replacedRequests = std::move(activeRequests_);
-            activeRequests_ = std::move(nextActiveRequests);
-            requestId_ = requestId;
-            requestInfos_ = std::move(nextRequestInfos);
-            requestStatuses_ = std::move(nextRequestStatuses);
-            desiredTileKeys_ = std::move(desiredTileKeys);
-            tilePriorityRanks_ = std::move(nextTilePriorityRanks);
-            // When request scope shrinks, remove stale tile data already queued for send.
-            filterOutgoingByDesiredLocked();
+            if (updateMode == ClientRequestUpdateMode::Append && requestId_ == requestId) {
+                for (auto& request : nextActiveRequests) {
+                    activeRequests_.push_back(std::move(request));
+                }
+                for (auto& info : nextRequestInfos) {
+                    requestInfos_.push_back(std::move(info));
+                }
+                for (auto status : nextRequestStatuses) {
+                    requestStatuses_.push_back(status);
+                }
+                desiredTileKeys_.insert(desiredTileKeys.begin(), desiredTileKeys.end());
+                for (auto const& [tileKey, priorityRank] : nextTilePriorityRanks) {
+                    tilePriorityRanks_.emplace(tileKey, priorityRank);
+                }
+            } else {
+                replacedRequests = std::move(activeRequests_);
+                activeRequests_ = std::move(nextActiveRequests);
+                requestId_ = requestId;
+                requestInfos_ = std::move(nextRequestInfos);
+                requestStatuses_ = std::move(nextRequestStatuses);
+                desiredTileKeys_ = std::move(desiredTileKeys);
+                tilePriorityRanks_ = std::move(nextTilePriorityRanks);
+                // When request scope shrinks, remove stale tile data already queued for send.
+                filterOutgoingByDesiredLocked();
+            }
+            requestChunksComplete_ = requestChunksComplete;
             // Refresh ordering so queued tiles follow the latest request priority.
             reprioritizeOutgoingLocked();
             statusEmissionEnabled_ = true;
@@ -1257,6 +1442,7 @@ private:
 
         {
             std::lock_guard lock(mutex_);
+            allDone = requestChunksComplete_;
             for (size_t i = 0; i < requestInfos_.size(); ++i) {
                 const auto status = (i < requestStatuses_.size()) ? requestStatuses_[i] : RequestStatus::Open;
                 allDone &= (status != RequestStatus::Open);
@@ -1325,6 +1511,9 @@ private:
     std::map<MapTileKey, int64_t> tilePriorityRanks_;
     std::map<MapTileKey, int64_t> queuedTileFrameRefCount_;
     bool statusEmissionEnabled_ = false;
+    uint64_t pendingChunkedRequestId_ = 0;
+    uint64_t pendingChunkedNextIndex_ = 0;
+    bool requestChunksComplete_ = true;
 
     TileLayerStream::StringPoolOffsetMap committedStringPoolOffsets_;
     TileLayerStream::StringPoolOffsetMap writerOffsets_;
@@ -1416,7 +1605,7 @@ public:
             }
 
             const auto requestId = session->allocateRequestId(j);
-            session->updateFromClientRequest(j, requestId);
+            session->updateFromClientRequestMessage(j, requestId);
         }
         catch (const std::exception& e) {
             log().error("WebSocket message handler failed: {}", e.what());

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -63,6 +63,27 @@ class TileFeatureLayer : public TileLayer, public simfil::ModelPool
 public:
     // Keep ModelPool::resolve<T> overloads visible alongside the override below.
     using ModelPool::resolve;
+    using Ptr = std::shared_ptr<TileFeatureLayer>;
+
+    struct CloneCacheKey
+    {
+        TileFeatureLayer const* model_ = nullptr;
+        uint32_t address_ = 0;
+
+        [[nodiscard]] bool operator==(CloneCacheKey const& other) const = default;
+    };
+
+    struct CloneCacheKeyHash
+    {
+        [[nodiscard]] size_t operator()(CloneCacheKey const& key) const noexcept
+        {
+            auto const modelHash = std::hash<TileFeatureLayer const*>{}(key.model_);
+            auto const addressHash = std::hash<uint32_t>{}(key.address_);
+            return modelHash ^ (addressHash + 0x9e3779b9U + (modelHash << 6U) + (modelHash >> 2U));
+        }
+    };
+
+    using CloneCache = std::unordered_map<CloneCacheKey, simfil::ModelNode::Ptr, CloneCacheKeyHash>;
 
     /**
      * This constructor initializes a new TileFeatureLayer instance.
@@ -257,9 +278,6 @@ public:
     model_ptr<Feature> find(std::string_view const& type, KeyValueViewPairs const& queryIdParts) const;
     model_ptr<Feature> find(std::string_view const& type, KeyValuePairs const& queryIdParts) const;
 
-    /** Shared pointer type */
-    using Ptr = std::shared_ptr<TileFeatureLayer>;
-
     /** Optional staged-loading index (0-based) for this feature tile. */
     [[nodiscard]] std::optional<uint32_t> stage() const override;
     void setStage(std::optional<uint32_t> stage) override;
@@ -340,7 +358,7 @@ public:
      * be appended to the existing feature.
      */
     void clone(
-        std::unordered_map<uint32_t, simfil::ModelNode::Ptr>& clonedModelNodes,
+        CloneCache& clonedModelNodes,
         TileFeatureLayer::Ptr const& otherLayer,
         Feature const& otherFeature,
         std::string_view const& type,
@@ -352,7 +370,7 @@ public:
      * of nodes which are referenced multiple times.
      */
     simfil::ModelNode::Ptr clone(
-        std::unordered_map<uint32_t, simfil::ModelNode::Ptr>& clonedModelNodes,
+        CloneCache& clonedModelNodes,
         TileFeatureLayer::Ptr const& otherLayer,
         simfil::ModelNode::Ptr const& otherNode);
 

--- a/libs/model/src/attrlayer.cpp
+++ b/libs/model/src/attrlayer.cpp
@@ -92,7 +92,8 @@ bool AttributeLayerList::forEachLayer(
 {
     if (!cb)
         return false;
-    for(auto const& [stringId, value] : fields()) {
+    auto local = localObject();
+    for (auto const& [stringId, value] : local->fields()) {
         if (auto layerName = model().strings()->resolve(stringId)) {
             if (value->addr().column() != TileFeatureLayer::ColumnId::AttributeLayers) {
                 log().warn("Don't add anything other than AttributeLayers into AttributeLayerLists!");
@@ -102,6 +103,9 @@ bool AttributeLayerList::forEachLayer(
             if (!cb(*layerName, attrLayer))
                 return false;
         }
+    }
+    if (auto ext = extension()) {
+        return ext->forEachLayer(cb);
     }
     return true;
 }

--- a/libs/model/src/featureid.cpp
+++ b/libs/model/src/featureid.cpp
@@ -226,8 +226,11 @@ std::string FeatureId::toString() const
     }
 
     if (values_) {
-        for (auto const& value : *values_) {
-            appendNodeValueToString(result, value);
+        auto const limit = std::min<size_t>(partNames_.size(), visibleValueIndices_.size());
+        for (size_t i = 0; i < limit; ++i) {
+            appendNodeValueToString(
+                result,
+                values_->at(static_cast<int64_t>(visibleValueIndices_[i])));
         }
     }
 

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -2034,17 +2034,18 @@ TileFeatureLayer::setStrings(std::shared_ptr<simfil::StringPool> const& newDict)
 }
 
 ModelNode::Ptr TileFeatureLayer::clone(
-    std::unordered_map<uint32_t, ModelNode::Ptr>& cache,
+    CloneCache& cache,
     const TileFeatureLayer::Ptr& otherLayer,
     const ModelNode::Ptr& otherNode)
 {
-    auto it = cache.find(otherNode->addr().value_);
+    auto const cacheKey = CloneCacheKey{otherLayer.get(), otherNode->addr().value_};
+    auto it = cache.find(cacheKey);
     if (it != cache.end()) {
         return it->second;
     }
 
     using namespace simfil;
-    ModelNode::Ptr& newCacheNode = cache[otherNode->addr().value_];
+    ModelNode::Ptr& newCacheNode = cache[cacheKey];
     switch (otherNode->addr().column()) {
     case Objects: {
         auto resolved = otherLayer->resolve<simfil::Object>(otherNode);
@@ -2296,12 +2297,12 @@ ModelNode::Ptr TileFeatureLayer::clone(
         newCacheNode = resolve(otherNode->addr());
     }
     }
-    cache.insert({otherNode->addr().value_, newCacheNode});
+    cache.insert({cacheKey, newCacheNode});
     return newCacheNode;
 }
 
 void TileFeatureLayer::clone(
-    std::unordered_map<uint32_t, ModelNode::Ptr>& clonedModelNodes,
+    CloneCache& clonedModelNodes,
     const TileFeatureLayer::Ptr& otherLayer,
     const Feature& otherFeature,
     const std::string_view& type,
@@ -2323,6 +2324,12 @@ void TileFeatureLayer::clone(
         return clone(clonedModelNodes, otherLayer, n);
     };
 
+    auto owningLayer =
+        [](auto const& nodePtr) -> TileFeatureLayer::Ptr
+    {
+        return std::static_pointer_cast<TileFeatureLayer>(nodePtr->model().shared_from_this());
+    };
+
     // Adopt attributes
     if (auto attrs = otherFeature.attributesOrNull()) {
         auto baseAttrs = cloneTarget->attributes();
@@ -2336,21 +2343,23 @@ void TileFeatureLayer::clone(
     // Adopt attribute layers
     if (auto attrLayers = otherFeature.attributeLayersOrNull()) {
         auto baseAttrLayers = cloneTarget->attributeLayers();
-        for (auto const& [key, value] : attrLayers->fields()) {
-            if (auto keyStr = otherLayer->strings()->resolve(key)) {
-                baseAttrLayers->addLayer(*keyStr, resolve<AttributeLayer>(*lookupOrClone(value)));
-            }
-        }
+        attrLayers->forEachLayer(
+            [this, &baseAttrLayers, &clonedModelNodes, &owningLayer](std::string_view layerName, model_ptr<AttributeLayer> const& layer)
+            {
+                auto cloned = clone(clonedModelNodes, owningLayer(layer), ModelNode::Ptr(layer));
+                baseAttrLayers->addLayer(layerName, resolve<AttributeLayer>(*cloned));
+                return true;
+            });
     }
 
     // Adopt geometries
     if (auto geom = otherFeature.geomOrNull()) {
         auto baseGeom = cloneTarget->geom();
         geom->forEachGeometry(
-            [this, &baseGeom, &lookupOrClone](auto&& geomElement)
+            [this, &baseGeom, &clonedModelNodes, &owningLayer](auto&& geomElement)
             {
                 baseGeom->addGeometry(
-                    resolve<Geometry>(*lookupOrClone(geomElement)));
+                    resolve<Geometry>(*clone(clonedModelNodes, owningLayer(geomElement), ModelNode::Ptr(geomElement))));
                 return true;
             });
     }
@@ -2358,9 +2367,9 @@ void TileFeatureLayer::clone(
     // Adopt relations
     if (otherFeature.numRelations()) {
         otherFeature.forEachRelation(
-            [this, &cloneTarget, &lookupOrClone](auto&& rel)
+            [this, &cloneTarget, &clonedModelNodes, &owningLayer](auto&& rel)
             {
-                auto newRel = resolve<Relation>(*lookupOrClone(rel));
+                auto newRel = resolve<Relation>(*clone(clonedModelNodes, owningLayer(rel), ModelNode::Ptr(rel)));
                 cloneTarget->addRelation(newRel);
                 return true;
             });

--- a/libs/service/include/mapget/service/service.h
+++ b/libs/service/include/mapget/service/service.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <chrono>
 #include <set>
+#include <vector>
 
 namespace mapget
 {
@@ -48,11 +49,25 @@ public:
         std::string layerId,
         std::vector<TileId> tiles);
 
+    /** Construct an unstaged request with foreground tile IDs prioritized for scheduling. */
+    LayerTilesRequest(
+        std::string mapId,
+        std::string layerId,
+        std::vector<TileId> tiles,
+        std::vector<TileId> priorityTileIds);
+
     /** Construct a staged request with tile IDs grouped by next missing stage. */
     LayerTilesRequest(
         std::string mapId,
         std::string layerId,
         std::vector<std::vector<TileId>> tileIdsByNextStage);
+
+    /** Construct a staged request with foreground tile IDs prioritized for scheduling. */
+    LayerTilesRequest(
+        std::string mapId,
+        std::string layerId,
+        std::vector<std::vector<TileId>> tileIdsByNextStage,
+        std::vector<TileId> priorityTileIds);
 
     /** Get the current status of the request. */
     RequestStatus getStatus();
@@ -74,6 +89,13 @@ public:
      * Bucket index N means: send stage N and all higher stages for these IDs.
      */
     std::vector<std::vector<TileId>> tileIdsByNextStage_;
+
+    /**
+     * Tile IDs within this request that should be scheduled before regular
+     * tiles. This is a scheduling hint only; it does not add tiles to the
+     * request by itself.
+     */
+    std::set<TileId> priorityTileIds_;
 
     /**
      * True iff the request explicitly uses `tileIdsByNextStage`.

--- a/libs/service/include/mapget/service/service.h
+++ b/libs/service/include/mapget/service/service.h
@@ -54,7 +54,7 @@ public:
         std::string mapId,
         std::string layerId,
         std::vector<TileId> tiles,
-        std::vector<TileId> priorityTileIds);
+        std::vector<TileId> const& priorityTileIds);
 
     /** Construct a staged request with tile IDs grouped by next missing stage. */
     LayerTilesRequest(
@@ -67,7 +67,7 @@ public:
         std::string mapId,
         std::string layerId,
         std::vector<std::vector<TileId>> tileIdsByNextStage,
-        std::vector<TileId> priorityTileIds);
+        std::vector<TileId> const& priorityTileIds);
 
     /** Get the current status of the request. */
     RequestStatus getStatus();

--- a/libs/service/src/service.cpp
+++ b/libs/service/src/service.cpp
@@ -762,7 +762,7 @@ struct Service::Impl : public Service::Controller
 
                 // Adopt new attributes, features and relations for the base feature
                 // from the auxiliary feature.
-                std::unordered_map<uint32_t, simfil::ModelNode::Ptr> clonedModelNodes;
+                TileFeatureLayer::CloneCache clonedModelNodes;
                 for (auto const& auxFeature : *auxTile)
                 {
                     // Note: A single secondary feature ID may resolve to multiple

--- a/libs/service/src/service.cpp
+++ b/libs/service/src/service.cpp
@@ -45,11 +45,6 @@ std::vector<std::vector<TileId>> normalizeTileBuckets(std::vector<std::vector<Ti
     return buckets;
 }
 
-std::set<TileId> normalizePriorityTileIds(std::vector<TileId> const& priorityTileIds)
-{
-    return {priorityTileIds.begin(), priorityTileIds.end()};
-}
-
 }  // namespace
 
 LayerTilesRequest::LayerTilesRequest(
@@ -68,7 +63,7 @@ LayerTilesRequest::LayerTilesRequest(
     std::string mapId,
     std::string layerId,
     std::vector<TileId> tiles,
-    std::vector<TileId> priorityTileIds)
+    std::vector<TileId> const& priorityTileIds)
     : LayerTilesRequest(
           std::move(mapId),
           std::move(layerId),
@@ -94,11 +89,11 @@ LayerTilesRequest::LayerTilesRequest(
     std::string mapId,
     std::string layerId,
     std::vector<std::vector<TileId>> tileIdsByNextStage,
-    std::vector<TileId> priorityTileIds)
+    std::vector<TileId> const& priorityTileIds)
     : mapId_(std::move(mapId)),
       layerId_(std::move(layerId)),
       tileIdsByNextStage_(normalizeTileBuckets(std::move(tileIdsByNextStage))),
-      priorityTileIds_(normalizePriorityTileIds(priorityTileIds))
+      priorityTileIds_({priorityTileIds.begin(), priorityTileIds.end()})
 {
     usesStageBuckets_ = true;
     bool hasAnyTileIds = false;

--- a/libs/service/src/service.cpp
+++ b/libs/service/src/service.cpp
@@ -45,6 +45,11 @@ std::vector<std::vector<TileId>> normalizeTileBuckets(std::vector<std::vector<Ti
     return buckets;
 }
 
+std::set<TileId> normalizePriorityTileIds(std::vector<TileId> const& priorityTileIds)
+{
+    return {priorityTileIds.begin(), priorityTileIds.end()};
+}
+
 }  // namespace
 
 LayerTilesRequest::LayerTilesRequest(
@@ -54,7 +59,21 @@ LayerTilesRequest::LayerTilesRequest(
     : LayerTilesRequest(
           std::move(mapId),
           std::move(layerId),
-          std::vector<std::vector<TileId>>{std::move(tiles)})
+          std::move(tiles),
+          {})
+{
+}
+
+LayerTilesRequest::LayerTilesRequest(
+    std::string mapId,
+    std::string layerId,
+    std::vector<TileId> tiles,
+    std::vector<TileId> priorityTileIds)
+    : LayerTilesRequest(
+          std::move(mapId),
+          std::move(layerId),
+          std::vector<std::vector<TileId>>{std::move(tiles)},
+          std::move(priorityTileIds))
 {
     usesStageBuckets_ = false;
 }
@@ -63,9 +82,23 @@ LayerTilesRequest::LayerTilesRequest(
     std::string mapId,
     std::string layerId,
     std::vector<std::vector<TileId>> tileIdsByNextStage)
+    : LayerTilesRequest(
+          std::move(mapId),
+          std::move(layerId),
+          std::move(tileIdsByNextStage),
+          {})
+{
+}
+
+LayerTilesRequest::LayerTilesRequest(
+    std::string mapId,
+    std::string layerId,
+    std::vector<std::vector<TileId>> tileIdsByNextStage,
+    std::vector<TileId> priorityTileIds)
     : mapId_(std::move(mapId)),
       layerId_(std::move(layerId)),
-      tileIdsByNextStage_(normalizeTileBuckets(std::move(tileIdsByNextStage)))
+      tileIdsByNextStage_(normalizeTileBuckets(std::move(tileIdsByNextStage))),
+      priorityTileIds_(normalizePriorityTileIds(priorityTileIds))
 {
     usesStageBuckets_ = true;
     bool hasAnyTileIds = false;
@@ -91,41 +124,69 @@ void LayerTilesRequest::prepareResolvedLayer(LayerType layerType, uint32_t stage
     tileKeysNotStarted_.clear();
 
     const auto normalizedStages = std::max<uint32_t>(1U, stages);
+    const auto isPriorityTile = [this](TileId const& tileId) {
+        return priorityTileIds_.find(tileId) != priorityTileIds_.end();
+    };
+    const auto appendKey = [this](MapTileKey key) {
+        if (tileKeysNotStarted_.insert(key).second) {
+            resolvedTileKeys_.push_back(std::move(key));
+        }
+    };
 
     if (!usesStageBuckets_) {
-        if (!tileIdsByNextStage_.empty()) {
+        const auto appendUnstagedTiles = [&](std::optional<bool> priorityFilter) {
+            if (tileIdsByNextStage_.empty()) {
+                return;
+            }
             for (auto const& tileId : tileIdsByNextStage_.front()) {
+                if (priorityFilter && isPriorityTile(tileId) != *priorityFilter) {
+                    continue;
+                }
                 MapTileKey key(
                     layerType,
                     mapId_,
                     layerId_,
                     tileId,
                     UnspecifiedStage);
-                if (tileKeysNotStarted_.insert(key).second) {
-                    resolvedTileKeys_.push_back(std::move(key));
-                }
+                appendKey(std::move(key));
             }
+        };
+
+        if (priorityTileIds_.empty()) {
+            appendUnstagedTiles(std::nullopt);
+        } else {
+            appendUnstagedTiles(true);
+            appendUnstagedTiles(false);
         }
         status_ = resolvedTileKeys_.empty() ? RequestStatus::Success : RequestStatus::Open;
         return;
     }
 
-    for (uint32_t stage = 0; stage < normalizedStages; ++stage) {
-        // For all tiles in bucket 0, we need to enqueue N stages.
-        // For tiles in bucket 1, we need to enqueue N-1 stages.
-        // etc.
-        for (size_t bucketIndex = 0; bucketIndex < tileIdsByNextStage_.size(); ++bucketIndex) {
-            const auto nextMissingStage = static_cast<uint32_t>(bucketIndex);
-            if (nextMissingStage > stage || nextMissingStage >= normalizedStages) {
-                continue;
-            }
-            for (auto const& tileId : tileIdsByNextStage_[bucketIndex]) {
-                MapTileKey key(layerType, mapId_, layerId_, tileId, stage);
-                if (tileKeysNotStarted_.insert(key).second) {
-                    resolvedTileKeys_.push_back(std::move(key));
+    const auto appendStagedTiles = [&](std::optional<bool> priorityFilter) {
+        for (uint32_t stage = 0; stage < normalizedStages; ++stage) {
+            // For all tiles in bucket 0, we need to enqueue N stages.
+            // For tiles in bucket 1, we need to enqueue N-1 stages.
+            // etc.
+            for (size_t bucketIndex = 0; bucketIndex < tileIdsByNextStage_.size(); ++bucketIndex) {
+                const auto nextMissingStage = static_cast<uint32_t>(bucketIndex);
+                if (nextMissingStage > stage || nextMissingStage >= normalizedStages) {
+                    continue;
+                }
+                for (auto const& tileId : tileIdsByNextStage_[bucketIndex]) {
+                    if (priorityFilter && isPriorityTile(tileId) != *priorityFilter) {
+                        continue;
+                    }
+                    appendKey(MapTileKey(layerType, mapId_, layerId_, tileId, stage));
                 }
             }
         }
+    };
+
+    if (priorityTileIds_.empty()) {
+        appendStagedTiles(std::nullopt);
+    } else {
+        appendStagedTiles(true);
+        appendStagedTiles(false);
     }
 
     status_ = resolvedTileKeys_.empty() ? RequestStatus::Success : RequestStatus::Open;
@@ -203,6 +264,13 @@ nlohmann::json LayerTilesRequest::toJson()
             }
         }
         requestJson["tileIds"] = std::move(tileIds);
+        if (!priorityTileIds_.empty()) {
+            auto priorityTileIds = nlohmann::json::array();
+            for (auto const& tileId : priorityTileIds_) {
+                priorityTileIds.emplace_back(tileId.value_);
+            }
+            requestJson["priorityTileIds"] = std::move(priorityTileIds);
+        }
         return requestJson;
     }
 
@@ -215,6 +283,13 @@ nlohmann::json LayerTilesRequest::toJson()
         tileIdsByNextStage.push_back(std::move(tileIds));
     }
     requestJson["tileIdsByNextStage"] = std::move(tileIdsByNextStage);
+    if (!priorityTileIds_.empty()) {
+        auto priorityTileIds = nlohmann::json::array();
+        for (auto const& tileId : priorityTileIds_) {
+            priorityTileIds.emplace_back(tileId.value_);
+        }
+        requestJson["priorityTileIds"] = std::move(priorityTileIds);
+    }
     return requestJson;
 }
 

--- a/libs/service/src/service.cpp
+++ b/libs/service/src/service.cpp
@@ -285,10 +285,8 @@ struct Service::Controller
         return {};
     }
 
-    [[nodiscard]] std::optional<Candidate> bestCandidate(DataSourceInfo const& info) const
+    [[nodiscard]] std::optional<Candidate> nextCandidateInRequestOrder(DataSourceInfo const& info) const
     {
-        std::optional<Candidate> best;
-
         for (auto reqIt = requests_.begin(); reqIt != requests_.end(); ++reqIt) {
             auto const& request = *reqIt;
             if (!requestMatchesDataSource(request, info))
@@ -299,17 +297,15 @@ struct Service::Controller
                 continue;
             auto pendingKey = request->resolvedTileKeys_[*pendingIndex];
 
-            if (!best || pendingKey.stage_ < best->tileKey_.stage_) {
-                best = Candidate{
-                    .requestIt_ = reqIt,
-                    .request_ = request,
-                    .tileKey_ = pendingKey,
-                    .nextTileIndex_ = *pendingIndex,
-                };
-            }
+            return Candidate{
+                .requestIt_ = reqIt,
+                .request_ = request,
+                .tileKey_ = pendingKey,
+                .nextTileIndex_ = *pendingIndex,
+            };
         }
 
-        return best;
+        return {};
     }
 
     void attachMatchingRequests(
@@ -338,6 +334,10 @@ struct Service::Controller
         request->nextTileIndex_ = candidate.nextTileIndex_;
         request->tileKeysNotStarted_.erase(candidate.tileKey_);
 
+        // Rotate on every consumed candidate. Cache hits and in-progress joins
+        // should participate in fairness just like newly started backend work.
+        requests_.splice(requests_.end(), requests_, candidate.requestIt_);
+
         auto cachedResult = cache_->getTileLayer(candidate.tileKey_, info);
         if (cachedResult.tile) {
             log().debug("Serving cached tile: {}", candidate.tileKey_.toString());
@@ -357,9 +357,6 @@ struct Service::Controller
         auto startedJob = std::make_shared<Job>(Job{candidate.tileKey_, {request}, cachedResult.expiredAt});
         attachMatchingRequests(request, candidate.tileKey_, startedJob->waitingRequests);
         jobsInProgress_.emplace(startedJob->tileKey, startedJob);
-
-        // Move this request to the end of the list, so others gain priority.
-        requests_.splice(requests_.end(), requests_, candidate.requestIt_);
         log().debug("Working on tile: {}", startedJob->tileKey.toString());
 
         return startedJob;
@@ -380,8 +377,8 @@ struct Service::Controller
         //  between sweeps to allow external updates.
 
         while (true) {
-            // 1) Pick highest-priority pending tile for this datasource worker.
-            auto candidate = bestCandidate(i);
+            // 1) Pick the next pending tile from the first matching request.
+            auto candidate = nextCandidateInRequestOrder(i);
             if (!candidate)
                 break;
 

--- a/test/unit/test-http-datasource.cpp
+++ b/test/unit/test-http-datasource.cpp
@@ -177,7 +177,7 @@ public:
                     "/tiles/next?clientId={}&waitMs={}&maxBytes={}",
                     clientId,
                     waitMs,
-                    5 * 1024 * 1024));
+                    64 * 1024 * 1024));
 
                 if (result != drogon::ReqResult::Ok || !resp) {
                     setError("Failed to pull next tile frame");

--- a/test/unit/test-model.cpp
+++ b/test/unit/test-model.cpp
@@ -1,4 +1,5 @@
 #include <catch2/catch_test_macros.hpp>
+#include <tuple>
 
 #include "mapget/model/featurelayer.h"
 #include "mapget/model/sourcedatareference.h"
@@ -959,6 +960,213 @@ TEST_CASE("FeatureLayer Overlay Merged Views", "[test.featurelayer.overlay]")
         REQUIRE(layersJson.contains("overlayLayer1"));
         REQUIRE(layersJson.contains("overlayLayer2"));
     }
+}
+
+TEST_CASE("FeatureLayer Overlay AttributeLayerList iteration uses owning model", "[test.featurelayer.overlay]")
+{
+    auto layerInfo = LayerInfo::fromJson(R"({
+        "layerId": "WayLayer",
+        "type": "Features",
+        "featureTypes": [
+            {
+                "name": "Way",
+                "uniqueIdCompositions": [
+                    [
+                        {
+                            "partId": "wayId",
+                            "description": "Globally unique 32b integer.",
+                            "datatype": "U32"
+                        }
+                    ]
+                ]
+            }
+        ]
+    })"_json);
+
+    auto strings = std::make_shared<StringPool>("OverlayNode");
+
+    auto makeTile = [&](std::string const& nodeName) {
+        return std::make_shared<TileFeatureLayer>(
+            TileId::fromWgs84(42., 11., 13),
+            nodeName,
+            "OverlayMap",
+            layerInfo,
+            strings);
+    };
+
+    auto base = makeTile("OverlayNode");
+    auto overlay = makeTile("OverlayNode");
+
+    auto baseFeature = base->newFeature("Way", {{"wayId", 1}});
+    auto dummyBaseLayer = baseFeature->attributeLayers()->newLayer("dummyBaseLayer");
+    auto dummyBaseAttr = dummyBaseLayer->newAttribute("dummyBaseAttr");
+    REQUIRE(dummyBaseAttr->addField("value", "dummy").has_value());
+    auto baseLayer = baseFeature->attributeLayers()->newLayer("baseLayer");
+    auto baseAttr = baseLayer->newAttribute("baseAttr");
+    REQUIRE(baseAttr->addField("value", "base").has_value());
+
+    auto overlayFeature = overlay->newFeature("Way", {{"wayId", 1}});
+    auto overlayLayer = overlayFeature->attributeLayers()->newLayer("overlayLayer");
+    auto overlayAttr = overlayLayer->newAttribute("overlayAttr");
+    REQUIRE(overlayAttr->addField("value", "overlay").has_value());
+
+    base->attachOverlay(overlay);
+
+    auto mergedFeature = base->at(0);
+    REQUIRE(mergedFeature);
+
+    std::vector<std::tuple<std::string, std::string, std::string>> layersSeen;
+    auto mergedLayers = mergedFeature->attributeLayersOrNull();
+    REQUIRE(mergedLayers);
+    REQUIRE(mergedLayers->forEachLayer(
+        [&](std::string_view layerName, model_ptr<AttributeLayer> const& layer) {
+            return layer->forEachAttribute([&](model_ptr<Attribute> const& attr) {
+                std::string fieldValue;
+                REQUIRE(attr->forEachField([&](std::string_view const& key, simfil::ModelNode::Ptr const& value) {
+                    if (key == "value") {
+                        auto scalar = value->value();
+                        if (auto const* s = std::get_if<std::string>(&scalar)) {
+                            fieldValue = *s;
+                        } else if (auto const* sv = std::get_if<std::string_view>(&scalar)) {
+                            fieldValue = std::string(*sv);
+                        }
+                    }
+                    return true;
+                }));
+                layersSeen.emplace_back(std::string(layerName), std::string(attr->name()), fieldValue);
+                return true;
+            });
+        }));
+
+    REQUIRE(layersSeen == std::vector<std::tuple<std::string, std::string, std::string>>{
+        {"dummyBaseLayer", "dummyBaseAttr", "dummy"},
+        {"baseLayer", "baseAttr", "base"},
+        {"overlayLayer", "overlayAttr", "overlay"},
+    });
+}
+
+TEST_CASE("FeatureLayer clone preserves merged staged attribute layers geometry and relations", "[test.featurelayer.overlay]")
+{
+    auto layerInfo = LayerInfo::fromJson(R"({
+        "layerId": "WayLayer",
+        "type": "Features",
+        "featureTypes": [
+            {
+                "name": "Way",
+                "uniqueIdCompositions": [
+                    [
+                        {
+                            "partId": "wayId",
+                            "description": "Globally unique 32b integer.",
+                            "datatype": "U32"
+                        }
+                    ]
+                ]
+            }
+        ]
+    })"_json);
+
+    auto strings = std::make_shared<StringPool>("OverlayNode");
+
+    auto makeTile = [&](std::string const& nodeName) {
+        return std::make_shared<TileFeatureLayer>(
+            TileId::fromWgs84(42., 11., 13),
+            nodeName,
+            "OverlayMap",
+            layerInfo,
+            strings);
+    };
+
+    auto target = makeTile("TargetNode");
+    auto sourceBase = makeTile("OverlayNode");
+    auto sourceOverlay = makeTile("OverlayNode");
+
+    auto sourceBaseFeature = sourceBase->newFeature("Way", {{"wayId", 1}});
+    auto sourceBaseGeom = sourceBaseFeature->geom()->newGeometry(GeomType::Points, 1);
+    sourceBaseGeom->append({10., 10., 0.});
+    auto dummyBaseLayer = sourceBaseFeature->attributeLayers()->newLayer("dummyBaseLayer");
+    auto dummyBaseAttr = dummyBaseLayer->newAttribute("dummyBaseAttr");
+    REQUIRE(dummyBaseAttr->addField("value", "dummy").has_value());
+    auto sourceBaseLayer = sourceBaseFeature->attributeLayers()->newLayer("baseLayer");
+    auto sourceBaseAttr = sourceBaseLayer->newAttribute("baseAttr");
+    REQUIRE(sourceBaseAttr->addField("value", "base").has_value());
+    sourceBaseFeature->addRelation("baseRel", sourceBase->newFeatureId("Way", {{"wayId", 100}}));
+
+    auto sourceOverlayFeature = sourceOverlay->newFeature("Way", {{"wayId", 1}});
+    auto sourceOverlayGeom = sourceOverlayFeature->geom()->newGeometry(GeomType::Points, 1);
+    sourceOverlayGeom->append({20., 20., 0.});
+    auto sourceOverlayLayer = sourceOverlayFeature->attributeLayers()->newLayer("overlayLayer");
+    auto sourceOverlayAttr = sourceOverlayLayer->newAttribute("overlayAttr");
+    REQUIRE(sourceOverlayAttr->addField("value", "overlay").has_value());
+    sourceOverlayFeature->addRelation("overlayRel", sourceOverlay->newFeatureId("Way", {{"wayId", 101}}));
+
+    sourceBase->attachOverlay(sourceOverlay);
+
+    auto mergedSourceFeature = sourceBase->at(0);
+    REQUIRE(mergedSourceFeature);
+
+    TileFeatureLayer::CloneCache clonedModelNodes;
+    target->clone(clonedModelNodes, sourceBase, *mergedSourceFeature, "Way", {{"wayId", 1}});
+
+    auto clonedFeature = target->at(0);
+    REQUIRE(clonedFeature);
+
+    std::vector<std::tuple<std::string, std::string, std::string>> layersSeen;
+    auto clonedLayers = clonedFeature->attributeLayersOrNull();
+    REQUIRE(clonedLayers);
+    REQUIRE(clonedLayers->forEachLayer(
+        [&](std::string_view layerName, model_ptr<AttributeLayer> const& layer) {
+            return layer->forEachAttribute([&](model_ptr<Attribute> const& attr) {
+                std::string fieldValue;
+                REQUIRE(attr->forEachField([&](std::string_view const& key, simfil::ModelNode::Ptr const& value) {
+                    if (key == "value") {
+                        auto scalar = value->value();
+                        if (auto const* s = std::get_if<std::string>(&scalar)) {
+                            fieldValue = *s;
+                        } else if (auto const* sv = std::get_if<std::string_view>(&scalar)) {
+                            fieldValue = std::string(*sv);
+                        }
+                    }
+                    return true;
+                }));
+                layersSeen.emplace_back(std::string(layerName), std::string(attr->name()), fieldValue);
+                return true;
+            });
+        }));
+
+    REQUIRE(layersSeen == std::vector<std::tuple<std::string, std::string, std::string>>{
+        {"dummyBaseLayer", "dummyBaseAttr", "dummy"},
+        {"baseLayer", "baseAttr", "base"},
+        {"overlayLayer", "overlayAttr", "overlay"},
+    });
+
+    std::vector<glm::dvec3> firstPoints;
+    auto clonedGeom = clonedFeature->geomOrNull();
+    REQUIRE(clonedGeom);
+    REQUIRE(clonedGeom->forEachGeometry([&](model_ptr<Geometry> const& geom) {
+        bool gotPoint = false;
+        geom->forEachPoint([&](glm::dvec3 const& point) {
+            firstPoints.push_back(point);
+            gotPoint = true;
+            return false;
+        });
+        REQUIRE(gotPoint);
+        return true;
+    }));
+    REQUIRE(firstPoints.size() == 2);
+    REQUIRE(firstPoints[0].x == 10.0);
+    REQUIRE(firstPoints[0].y == 10.0);
+    REQUIRE(firstPoints[0].z == 0.0);
+    REQUIRE(firstPoints[1].x == 20.0);
+    REQUIRE(firstPoints[1].y == 20.0);
+    REQUIRE(firstPoints[1].z == 0.0);
+
+    std::vector<std::string> relationNames;
+    REQUIRE(clonedFeature->forEachRelation([&](model_ptr<Relation> const& relation) {
+        relationNames.emplace_back(relation->name());
+        return true;
+    }));
+    REQUIRE(relationNames == std::vector<std::string>{"baseRel", "overlayRel"});
 }
 
 TEST_CASE("FeatureLayer Overlay Size Check", "[test.featurelayer.overlay]")

--- a/test/unit/test-model.cpp
+++ b/test/unit/test-model.cpp
@@ -1,5 +1,8 @@
 #include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <string_view>
 #include <tuple>
+#include <vector>
 
 #include "mapget/model/featurelayer.h"
 #include "mapget/model/sourcedatareference.h"
@@ -9,6 +12,47 @@
 #include "nlohmann/json_fwd.hpp"
 
 using namespace mapget;
+
+namespace
+{
+
+using LayerAttributeValues = std::vector<std::tuple<std::string, std::string, std::string>>;
+
+std::string stringValue(simfil::ModelNode::Ptr const& value)
+{
+    auto scalar = value->value();
+    if (auto const* s = std::get_if<std::string>(&scalar)) {
+        return *s;
+    }
+    if (auto const* sv = std::get_if<std::string_view>(&scalar)) {
+        return std::string(*sv);
+    }
+    return {};
+}
+
+LayerAttributeValues collectLayerAttributeValues(model_ptr<AttributeLayerList> const& layers)
+{
+    LayerAttributeValues result;
+    REQUIRE(layers);
+    REQUIRE(layers->forEachLayer(
+        [&](std::string_view layerName, model_ptr<AttributeLayer> const& layer) {
+            return layer->forEachAttribute([&](model_ptr<Attribute> const& attr) {
+                std::string fieldValue;
+                REQUIRE(attr->forEachField(
+                    [&](std::string_view const& key, simfil::ModelNode::Ptr const& value) {
+                        if (key == "value") {
+                            fieldValue = stringValue(value);
+                        }
+                        return true;
+                    }));
+                result.emplace_back(std::string(layerName), std::string(attr->name()), fieldValue);
+                return true;
+            });
+        }));
+    return result;
+}
+
+}  // namespace
 
 TEST_CASE("FeatureLayer", "[test.featurelayer]")
 {
@@ -1015,28 +1059,7 @@ TEST_CASE("FeatureLayer Overlay AttributeLayerList iteration uses owning model",
     auto mergedFeature = base->at(0);
     REQUIRE(mergedFeature);
 
-    std::vector<std::tuple<std::string, std::string, std::string>> layersSeen;
-    auto mergedLayers = mergedFeature->attributeLayersOrNull();
-    REQUIRE(mergedLayers);
-    REQUIRE(mergedLayers->forEachLayer(
-        [&](std::string_view layerName, model_ptr<AttributeLayer> const& layer) {
-            return layer->forEachAttribute([&](model_ptr<Attribute> const& attr) {
-                std::string fieldValue;
-                REQUIRE(attr->forEachField([&](std::string_view const& key, simfil::ModelNode::Ptr const& value) {
-                    if (key == "value") {
-                        auto scalar = value->value();
-                        if (auto const* s = std::get_if<std::string>(&scalar)) {
-                            fieldValue = *s;
-                        } else if (auto const* sv = std::get_if<std::string_view>(&scalar)) {
-                            fieldValue = std::string(*sv);
-                        }
-                    }
-                    return true;
-                }));
-                layersSeen.emplace_back(std::string(layerName), std::string(attr->name()), fieldValue);
-                return true;
-            });
-        }));
+    auto layersSeen = collectLayerAttributeValues(mergedFeature->attributeLayersOrNull());
 
     REQUIRE(layersSeen == std::vector<std::tuple<std::string, std::string, std::string>>{
         {"dummyBaseLayer", "dummyBaseAttr", "dummy"},
@@ -1111,28 +1134,7 @@ TEST_CASE("FeatureLayer clone preserves merged staged attribute layers geometry 
     auto clonedFeature = target->at(0);
     REQUIRE(clonedFeature);
 
-    std::vector<std::tuple<std::string, std::string, std::string>> layersSeen;
-    auto clonedLayers = clonedFeature->attributeLayersOrNull();
-    REQUIRE(clonedLayers);
-    REQUIRE(clonedLayers->forEachLayer(
-        [&](std::string_view layerName, model_ptr<AttributeLayer> const& layer) {
-            return layer->forEachAttribute([&](model_ptr<Attribute> const& attr) {
-                std::string fieldValue;
-                REQUIRE(attr->forEachField([&](std::string_view const& key, simfil::ModelNode::Ptr const& value) {
-                    if (key == "value") {
-                        auto scalar = value->value();
-                        if (auto const* s = std::get_if<std::string>(&scalar)) {
-                            fieldValue = *s;
-                        } else if (auto const* sv = std::get_if<std::string_view>(&scalar)) {
-                            fieldValue = std::string(*sv);
-                        }
-                    }
-                    return true;
-                }));
-                layersSeen.emplace_back(std::string(layerName), std::string(attr->name()), fieldValue);
-                return true;
-            });
-        }));
+    auto layersSeen = collectLayerAttributeValues(clonedFeature->attributeLayersOrNull());
 
     REQUIRE(layersSeen == std::vector<std::tuple<std::string, std::string, std::string>>{
         {"dummyBaseLayer", "dummyBaseAttr", "dummy"},

--- a/test/unit/test-service-ttl.cpp
+++ b/test/unit/test-service-ttl.cpp
@@ -211,4 +211,22 @@ TEST_CASE("LayerTilesRequest preserves staged intent in JSON", "[Service][JSON]"
             })},
         });
     }
+
+    SECTION("Priority tile IDs are serialized as scheduling hints")
+    {
+        auto request = std::make_shared<TestLayerTilesRequest>(
+            "Tropico",
+            "WayLayer",
+            std::vector<std::vector<TileId>>{{TileId(12345), TileId(67890)}},
+            std::vector<TileId>{TileId(67890)});
+
+        REQUIRE(request->toJson() == nlohmann::json{
+            {"mapId", "Tropico"},
+            {"layerId", "WayLayer"},
+            {"tileIdsByNextStage", nlohmann::json::array({
+                nlohmann::json::array({12345, 67890})
+            })},
+            {"priorityTileIds", nlohmann::json::array({67890})},
+        });
+    }
 }


### PR DESCRIPTION
## Release 2026.1.3

### TODOs

- [x] Merge this PR before the dependent livesource, erdblick, and top-level mapviewer release PRs.
- [x] Tag and publish `v2026.1.3` after verification.

### Changes

- Adjust websocket message size limit, add try/catch blocks for robustness. Fixes #155 
- Ensure that concurrent users cannot block higher-stage loading for others (https://github.com/ndsev/erdblick/issues/346)

**Already Released with 2026.1.2 but not on main:**

- Fix bad feature id serialization path.
- Avoid stage mix-ups in feature layer/model access.
