### PR TITLE
Geojson Endpoint with Full Conversion

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -34,7 +34,7 @@ if (NOT "${_mapget_simfil_source_dir}" STREQUAL "")
             "SIMFIL_SHARED OFF")
 else()
     CPMAddPackage(
-        URI "gh:Klebert-Engineering/simfil#release/0.7.1"
+        URI "gh:Klebert-Engineering/simfil@0.7.1"
         OPTIONS
             "SIMFIL_WITH_MODEL_JSON ON"
             "SIMFIL_SHARED OFF")

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -34,7 +34,7 @@ if (NOT "${_mapget_simfil_source_dir}" STREQUAL "")
             "SIMFIL_SHARED OFF")
 else()
     CPMAddPackage(
-        URI "gh:Klebert-Engineering/simfil#v0.7.0"
+        URI "gh:Klebert-Engineering/simfil#release/0.7.1"
         OPTIONS
             "SIMFIL_WITH_MODEL_JSON ON"
             "SIMFIL_SHARED OFF")
@@ -161,7 +161,7 @@ if (MAPGET_WITH_SERVICE OR MAPGET_WITH_HTTPLIB OR MAPGET_ENABLE_TESTING)
 endif()
 
 if (MAPGET_WITH_WHEEL AND NOT TARGET python-cmake-wheel)
-    CPMAddPackage("gh:Klebert-Engineering/python-cmake-wheel#v1.2.7@1.2.7")
+    CPMAddPackage("gh:Klebert-Engineering/python-cmake-wheel#v1.2.8@1.2.8")
 endif()
 
 if (MAPGET_ENABLE_TESTING)

--- a/docs/mapget-api.md
+++ b/docs/mapget-api.md
@@ -111,10 +111,6 @@ Each line in the JSONL response is a GeoJSON-like FeatureCollection with additio
   "mapgetTileId": 281479271743500,
   "mapId": "EuropeHD",
   "mapgetLayerId": "Roads",
-  "idPrefix": {
-    "areaId": 123,
-    "tileId": 456
-  },
   "timestamp": "2025-01-14T10:30:00.000000Z",
   "ttl": 3600000,
   "error": {
@@ -131,7 +127,6 @@ Each line in the JSONL response is a GeoJSON-like FeatureCollection with additio
 | `mapgetTileId` | integer | The mapget tile ID (64-bit decimal) |
 | `mapId` | string | Map identifier |
 | `mapgetLayerId` | string | Layer identifier within the map |
-| `idPrefix` | object | Common ID parts shared by all features in this tile (optional) |
 | `timestamp` | string | ISO 8601 timestamp when the tile was created |
 | `ttl` | integer | Time-to-live in milliseconds (optional) |
 | `error` | object | Error information if tile creation failed (optional) |

--- a/docs/mapget-api.md
+++ b/docs/mapget-api.md
@@ -111,7 +111,7 @@ Each line in the JSONL response is a GeoJSON-like FeatureCollection with additio
   "mapgetTileId": 281479271743500,
   "mapId": "EuropeHD",
   "mapgetLayerId": "Roads",
-  "timestamp": "2025-01-14T10:30:00.000000Z",
+  "timestamp": 1736850600000000,
   "ttl": 3600000,
   "error": {
     "code": 404,
@@ -127,7 +127,7 @@ Each line in the JSONL response is a GeoJSON-like FeatureCollection with additio
 | `mapgetTileId` | integer | The mapget tile ID (64-bit decimal) |
 | `mapId` | string | Map identifier |
 | `mapgetLayerId` | string | Layer identifier within the map |
-| `timestamp` | string | ISO 8601 timestamp when the tile was created |
+| `timestamp` | integer | Tile creation time in microseconds since the Unix epoch |
 | `ttl` | integer | Time-to-live in milliseconds (optional) |
 | `error` | object | Error information if tile creation failed (optional) |
 | `error.code` | integer | Numeric error code, e.g., HTTP status or database error (optional) |

--- a/docs/mapget-config.md
+++ b/docs/mapget-config.md
@@ -35,7 +35,8 @@ By default, the HTTP service registers the following datasource types:
 - `DataSourceHost` – connect to a remote `DataSourceServer` over HTTP.
 - `DataSourceProcess` – spawn a datasource process locally and connect to it.
 - `GridDataSource` – generate synthetic tiles on the fly for testing and benchmarking.
-- `GeoJsonFolder` – serve features from a directory containing `.geojson` files named by tile ID.
+- `GeoJsonFolder` – serve features from local GeoJSON files.
+- `GeoJsonEndpoint` – serve features from GeoJSON files fetched over HTTP.
 
 Additional datasource types can be registered from C++ code using `DataSourceConfigService`, but those are outside the scope of this guide.
 
@@ -205,6 +206,8 @@ Optional fields:
 
 - `mapId`: optional map ID override. If omitted, mapget derives a display name from the input directory.
 - `withAttrLayers` (default: `true`): boolean flag. If `true`, nested objects in the GeoJSON `properties` are converted to mapget attribute layers; if `false`, only scalar top‑level properties are emitted and nested objects are silently dropped.
+- `dataSourceInfo`: inline datasource info object, local YAML/JSON file path, or HTTP(S) URL.
+- `tilePathTemplate`: relative path template used when `dataSourceInfo` is configured. Supported placeholders are `{tileId}` and `{layerId}`.
 
 Example:
 
@@ -216,9 +219,26 @@ sources:
     withAttrLayers: true
 ```
 
-#### Manifest Mode (Recommended)
+Example with explicit layer metadata and template-based file lookup:
 
-If a `manifest.json` file exists in the input directory, it is used to map filenames to tile IDs and layers. This allows arbitrary filenames and multi‑layer support.
+```yaml
+sources:
+  - type: GeoJsonFolder
+    folder: /data/tiles
+    dataSourceInfo: /data/tiles/info.yaml
+    tilePathTemplate: "{layerId}/{tileId}.geojson"
+```
+
+If `dataSourceInfo` is omitted, mapget falls back to legacy discovery:
+
+- first it looks for a legacy `manifest.json`
+- if no manifest exists, it scans the folder for files named `<tileId>.geojson`
+
+In that fallback mode, metadata is synthesized as a single `GeoJsonAny` layer and conversion is best-effort.
+
+#### Manifest Mode (Legacy)
+
+If no explicit `dataSourceInfo` is configured and a `manifest.json` file exists in the input directory, it is used to map filenames to tile IDs and layers. This allows arbitrary filenames and multi‑layer support.
 
 **Manifest Structure:**
 
@@ -275,6 +295,34 @@ This allows multiple GeoJSON files to contribute features to the same tile in di
 If no `manifest.json` exists, the datasource falls back to scanning for files named `<packed-tile-id>.geojson` (e.g., `123456.geojson`). All files are served from a single `GeoJsonAny` layer.
 
 <!-- --8<-- [end:geojson] -->
+
+### `GeoJsonEndpoint`
+
+`GeoJsonEndpoint` serves GeoJSON tiles from an HTTP(S) endpoint. It uses the same GeoJSON conversion logic as `GeoJsonFolder`, but fetches each tile body over the network.
+
+Required fields:
+
+- `type`: must be `GeoJsonEndpoint`.
+- `baseUrl`: base HTTP(S) URL used to fetch GeoJSON tiles.
+
+Optional fields:
+
+- `mapId`: optional map ID override. If omitted, mapget derives a display name from the base URL.
+- `withAttrLayers` (default: `true`): converts nested GeoJSON property objects to mapget attribute layers.
+- `dataSourceInfo`: inline datasource info object, local YAML/JSON file path, or HTTP(S) URL.
+- `tileUrlTemplate`: URL or relative path template used to fetch tiles. Supported placeholders are `{tileId}`, `{layerId}`, and `{baseUrl}`.
+
+Example:
+
+```yaml
+sources:
+  - type: GeoJsonEndpoint
+    baseUrl: https://example.test/tiles
+    dataSourceInfo: https://example.test/info.yaml
+    tileUrlTemplate: "{layerId}/{tileId}.geojson"
+```
+
+If `dataSourceInfo` is omitted, mapget emits a strong warning and falls back to a synthesized single-layer `GeoJsonAny` datasource with empty coverage. In that fallback mode, conversion is still attempted, but service discovery remains intentionally limited.
 
 ## HTTP settings for tools and UIs
 

--- a/docs/mapget-user-guide.md
+++ b/docs/mapget-user-guide.md
@@ -9,7 +9,7 @@ Most readers will only need the setup and API chapters. The model and configurat
 The guide is split into several focused documents:
 
 - [**Setup Guide**](mapget-setup.md) explains how to install mapget via `pip`, how to build the native executable from source, and how to start a server or use the built‑in `fetch` client for quick experiments.
-- [**Configuration Guide**](mapget-config.md) documents the YAML configuration file used with `--config`, the supported datasource types (`DataSourceHost`, `DataSourceProcess`, `GridDataSource`, `GeoJsonFolder) and the optional `http-settings` section used by tools and UIs.
+- [**Configuration Guide**](mapget-config.md) documents the YAML configuration file used with `--config`, the supported datasource types (`DataSourceHost`, `DataSourceProcess`, `GridDataSource`, `GeoJsonFolder`, `GeoJsonEndpoint`) and the optional `http-settings` section used by tools and UIs.
 - [**HTTP / WebSocket API Guide**](mapget-api.md) describes the endpoints exposed by `mapget serve`, including `/sources`, `/tiles`, `/tiles/next`, `/status`, `/status-data`, `/locate` and `/config`, along with their request and response formats and example calls.
 - [**Caching Guide**](mapget-cache.md) covers the available cache modes (`memory`, `persistent`, `none`), explains how to configure cache size and location, and shows how to inspect cache statistics via the status endpoint.
 - [**Simfil Language Extensions**](mapget-simfil-extensions.md) introduces the feature model, tiling scheme, geometry and validity concepts, and the binary tile stream format. This chapter is especially relevant if you are writing datasources or low‑level clients.

--- a/libs/geojsonsource/CMakeLists.txt
+++ b/libs/geojsonsource/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(geojsonsource
 
 target_link_libraries(geojsonsource
     PUBLIC
+        drogon
         mapget-model
         mapget-service)
 

--- a/libs/geojsonsource/CMakeLists.txt
+++ b/libs/geojsonsource/CMakeLists.txt
@@ -12,7 +12,8 @@ target_link_libraries(geojsonsource
     PUBLIC
         drogon
         mapget-model
-        mapget-service)
+        mapget-service
+        zlibstatic)
 
 if (MSVC)
     target_compile_definitions(geojsonsource

--- a/libs/geojsonsource/include/geojsonsource/geojsonsource.h
+++ b/libs/geojsonsource/include/geojsonsource/geojsonsource.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <functional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -100,6 +101,12 @@ struct GeoJsonEndpointSourceOptions
     std::string tileUrlTemplate;
     std::optional<nlohmann::json> dataSourceInfoJson;
     std::string dataSourceInfoLocation;
+
+    /**
+     * Optional text fetch override used for tests or custom transports.
+     * When unset, HTTP(S) URLs are fetched via the built-in HTTP client.
+     */
+    std::function<std::string(std::string const&)> fetchText;
 };
 
 /**
@@ -166,6 +173,7 @@ private:
     std::string baseUrl_;
     std::string tileUrlTemplate_;
     bool withAttrLayers_ = true;
+    std::function<std::string(std::string const&)> fetchText_;
 
     struct Impl;
     std::unique_ptr<Impl> impl_;

--- a/libs/geojsonsource/include/geojsonsource/geojsonsource.h
+++ b/libs/geojsonsource/include/geojsonsource/geojsonsource.h
@@ -1,29 +1,32 @@
 #pragma once
 
-#include <unordered_set>
-#include <unordered_map>
-#include <string>
 #include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "mapget/model/featurelayer.h"
 #include "mapget/model/sourcedatalayer.h"
 #include "mapget/service/datasource.h"
 
+#include <nlohmann/json.hpp>
+
 namespace mapget::geojsonsource
 {
 
 /**
- * Entry describing a single GeoJSON file in the manifest.
+ * Entry describing a single GeoJSON file in the legacy manifest.
  */
 struct FileEntry
 {
     std::string filename;
     uint64_t tileId = 0;
-    std::string layer;  // Empty means use default layer
+    std::string layer;
 };
 
 /**
- * Metadata section of the manifest (all fields optional).
+ * Metadata section of the legacy GeoJSON manifest.
  */
 struct ManifestMetadata
 {
@@ -36,7 +39,7 @@ struct ManifestMetadata
 };
 
 /**
- * Parsed manifest.json structure.
+ * Parsed legacy manifest.json structure.
  */
 struct Manifest
 {
@@ -47,115 +50,125 @@ struct Manifest
 };
 
 /**
- * Key for looking up files by (tileId, layer).
+ * Key for looking up legacy manifest files by tile and layer.
  */
 struct TileLayerKey
 {
-    uint64_t tileId;
+    uint64_t tileId = 0;
     std::string layer;
 
-    bool operator==(const TileLayerKey& other) const {
+    bool operator==(const TileLayerKey& other) const
+    {
         return tileId == other.tileId && layer == other.layer;
     }
 };
 
 struct TileLayerKeyHash
 {
-    std::size_t operator()(const TileLayerKey& k) const {
-        return std::hash<uint64_t>()(k.tileId) ^ (std::hash<std::string>()(k.layer) << 1);
+    std::size_t operator()(const TileLayerKey& key) const
+    {
+        return std::hash<uint64_t>()(key.tileId) ^ (std::hash<std::string>()(key.layer) << 1);
     }
 };
 
 /**
- * Data Source which may be used to load GeoJSON files from a directory.
+ * Optional overrides for GeoJsonFolder.
  *
- * Supports two modes of operation:
+ * `dataSourceInfoJson` and `dataSourceInfoLocation` are mutually exclusive.
+ * The location may point to a local YAML/JSON file or to an HTTP(S) URL.
+ */
+struct GeoJsonSourceOptions
+{
+    bool withAttrLayers = true;
+    std::string mapId;
+    std::string tilePathTemplate;
+    std::optional<nlohmann::json> dataSourceInfoJson;
+    std::string dataSourceInfoLocation;
+};
+
+/**
+ * Optional overrides for GeoJsonEndpoint.
  *
- * 1. **Manifest mode** (recommended): If a `manifest.json` file exists in the
- *    input directory, it is used to map filenames to tile IDs and layers.
- *    This allows arbitrary filenames and multi-layer support.
+ * `dataSourceInfoJson` and `dataSourceInfoLocation` are mutually exclusive.
+ * The location may point to a local YAML/JSON file or to an HTTP(S) URL.
+ */
+struct GeoJsonEndpointSourceOptions
+{
+    std::string baseUrl;
+    bool withAttrLayers = true;
+    std::string mapId;
+    std::string tileUrlTemplate;
+    std::optional<nlohmann::json> dataSourceInfoJson;
+    std::string dataSourceInfoLocation;
+};
+
+/**
+ * Data source which loads GeoJSON tiles from a local folder.
  *
- *    Example manifest.json:
- *    ```json
- *    {
- *      "version": 1,
- *      "metadata": {
- *        "name": "My Dataset",
- *        "source": "OpenStreetMap",
- *        "created": "2024-01-15"
- *      },
- *      "index": {
- *        "defaultLayer": "GeoJsonAny",
- *        "files": {
- *          "roads.geojson": { "tileId": 121212121212, "layer": "Road" },
- *          "lanes.geojson": { "tileId": 121212121212, "layer": "Lane" },
- *          "other.geojson": { "tileId": 343434343434 }
- *        }
- *      }
- *    }
- *    ```
- *
- * 2. **Legacy mode**: If no manifest.json exists, falls back to scanning for
- *    files named `<packed-tile-id>.geojson`. All files go into a single
- *    "GeoJsonAny" layer.
- *
- * Note: This data source was mainly developed as a scalability test
- *  scenario for erdblick. In the future, the DBI will export the same
- *  GeoJSON feature model that is understood by mapget, and a GeoJSON
- *  data source will be part of the mapget code base.
+ * The datasource supports three modes:
+ * - explicit `dataSourceInfo` plus `tilePathTemplate`
+ * - legacy `manifest.json` filename mapping
+ * - legacy directory scanning for `<tileId>.geojson`
  */
 class GeoJsonSource : public mapget::DataSource
 {
 public:
-    /**
-     * Construct a GeoJSON data source from a directory.
-     *
-     * If a manifest.json exists in the directory, it will be used for
-     * file-to-tile mapping and layer configuration. Otherwise, falls back
-     * to legacy mode where files must be named `<tile-id>.geojson`.
-     *
-     * @param inputDir The directory with the GeoJSON files (and optional manifest.json).
-     * @param withAttrLayers Flag indicating whether compound GeoJSON
-     *  properties shall be converted to mapget attribute layers.
-     * @param mapId Optional map ID override. If empty, derived from inputDir.
-     */
-    GeoJsonSource(const std::string& inputDir, bool withAttrLayers, const std::string& mapId="");
+    GeoJsonSource(
+        const std::string& inputDir,
+        bool withAttrLayers,
+        const std::string& mapId = "");
+    explicit GeoJsonSource(std::string inputDir, GeoJsonSourceOptions options);
 
-    /** DataSource Interface */
     mapget::DataSourceInfo info() override;
     void fill(mapget::TileFeatureLayer::Ptr const&) override;
     void fill(mapget::TileSourceDataLayer::Ptr const&) override;
 
-    /** Returns true if a manifest.json was found and used. */
     [[nodiscard]] bool hasManifest() const { return hasManifest_; }
-
-    /** Returns the parsed manifest (only valid if hasManifest() is true). */
     [[nodiscard]] const Manifest& manifest() const { return manifest_; }
 
 private:
-    /** Parse manifest.json from the input directory. Returns true if found and valid. */
-    bool parseManifest();
-
-    /** Initialize coverage from manifest entries. */
+    [[nodiscard]] bool parseManifest();
     void initFromManifest();
-
-    /** Initialize coverage by scanning directory for <tile-id>.geojson files (legacy). */
     void initFromDirectory();
-
-    /** Create LayerInfo JSON for a given layer name. */
-    static nlohmann::json createLayerInfoJson(const std::string& layerName);
+    [[nodiscard]] std::string resolveTilePath(uint64_t tileId, std::string_view layerId) const;
+    [[nodiscard]] std::string readTileBody(uint64_t tileId, std::string_view layerId) const;
+    [[nodiscard]] static nlohmann::json createLayerInfoJson(const std::string& layerName);
 
     mapget::DataSourceInfo info_;
     std::string inputDir_;
     bool withAttrLayers_ = true;
     bool hasManifest_ = false;
+    bool usesTemplatePaths_ = false;
+    std::string tilePathTemplate_;
     Manifest manifest_;
-
-    // Mapping from (tileId, layer) -> filename
     std::unordered_map<TileLayerKey, std::string, TileLayerKeyHash> tileLayerToFile_;
-
-    // Set of covered tile IDs per layer (for legacy single-layer mode compatibility)
     std::unordered_map<std::string, std::unordered_set<uint64_t>> layerCoverage_;
+};
+
+/**
+ * Data source which loads GeoJSON tiles from an HTTP endpoint.
+ */
+class GeoJsonEndpointSource : public mapget::DataSource
+{
+public:
+    explicit GeoJsonEndpointSource(GeoJsonEndpointSourceOptions options);
+    ~GeoJsonEndpointSource();
+
+    mapget::DataSourceInfo info() override;
+    void fill(mapget::TileFeatureLayer::Ptr const&) override;
+    void fill(mapget::TileSourceDataLayer::Ptr const&) override;
+
+private:
+    [[nodiscard]] std::string renderTileUrl(uint64_t tileId, std::string_view layerId) const;
+    [[nodiscard]] std::string fetchTileBody(uint64_t tileId, std::string_view layerId) const;
+
+    mapget::DataSourceInfo info_;
+    std::string baseUrl_;
+    std::string tileUrlTemplate_;
+    bool withAttrLayers_ = true;
+
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace mapget::geojsonsource

--- a/libs/geojsonsource/src/geojsonsource.cpp
+++ b/libs/geojsonsource/src/geojsonsource.cpp
@@ -224,7 +224,8 @@ struct ParsedHttpUrl
 
 [[nodiscard]] std::optional<DataSourceInfo> loadConfiguredDataSourceInfo(
     std::optional<nlohmann::json> const& inlineJson,
-    std::string const& location)
+    std::string const& location,
+    std::function<std::string(std::string const&)> const& fetchText = {})
 {
     if (inlineJson && !location.empty()) {
         raise("`dataSourceInfoJson` and `dataSourceInfoLocation` cannot be used together.");
@@ -238,8 +239,10 @@ struct ParsedHttpUrl
         return std::nullopt;
 
     nlohmann::json infoJson;
-    if (looksLikeHttpUrl(location))
-        infoJson = parseStructuredDocument(fetchHttpTextOnce(location), location);
+    if (looksLikeHttpUrl(location)) {
+        auto body = fetchText ? fetchText(location) : fetchHttpTextOnce(location);
+        infoJson = parseStructuredDocument(body, location);
+    }
     else
         infoJson = loadStructuredDocumentFile(location);
     return DataSourceInfo::fromJson(infoJson);
@@ -643,7 +646,8 @@ struct GeoJsonEndpointSource::Impl
 GeoJsonEndpointSource::GeoJsonEndpointSource(GeoJsonEndpointSourceOptions options)
     : baseUrl_(trimmed(options.baseUrl)),
       tileUrlTemplate_(options.tileUrlTemplate.empty() ? "{tileId}.geojson" : options.tileUrlTemplate),
-      withAttrLayers_(options.withAttrLayers)
+      withAttrLayers_(options.withAttrLayers),
+      fetchText_(std::move(options.fetchText))
 {
     if (baseUrl_.empty())
         raise("GeoJsonEndpoint requires a non-empty `baseUrl`.");
@@ -654,7 +658,8 @@ GeoJsonEndpointSource::GeoJsonEndpointSource(GeoJsonEndpointSourceOptions option
 
     if (auto loadedInfo = loadConfiguredDataSourceInfo(
             options.dataSourceInfoJson,
-            options.dataSourceInfoLocation)) {
+            options.dataSourceInfoLocation,
+            fetchText_)) {
         info_ = std::move(*loadedInfo);
         finalizeLoadedInfo(info_, options.mapId);
     }
@@ -697,6 +702,9 @@ std::string GeoJsonEndpointSource::renderTileUrl(uint64_t tileId, std::string_vi
 std::string GeoJsonEndpointSource::fetchTileBody(uint64_t tileId, std::string_view layerId) const
 {
     auto url = renderTileUrl(tileId, layerId);
+    if (fetchText_)
+        return fetchText_(url);
+
     auto parsedUrl = splitHttpUrl(url);
     auto client = impl_->acquireClient(parsedUrl.origin);
 

--- a/libs/geojsonsource/src/geojsonsource.cpp
+++ b/libs/geojsonsource/src/geojsonsource.cpp
@@ -3,52 +3,321 @@
 #include "geojsonsource/geojsonsource.h"
 
 #include "mapget/log.h"
-#include "mapget/model/sourcedatalayer.h"
+#include "mapget/service/config.h"
 
-#include "nlohmann/json.hpp"
-#include "fmt/format.h"
+#include <drogon/HttpClient.h>
+#include <drogon/HttpRequest.h>
+#include <trantor/net/EventLoopThread.h>
 
+#include <algorithm>
+#include <cctype>
+#include <cmath>
 #include <filesystem>
 #include <fstream>
-#include <iostream>
+#include <mutex>
 #include <thread>
 #include <unordered_map>
+
+#include "fmt/format.h"
+
+#include <zlib.h>
 
 namespace
 {
 
-simfil::ModelNode::Ptr jsonToMapget(  // NOLINT (recursive)
-    mapget::TileFeatureLayer::Ptr const& tfl,
-    const nlohmann::json& j)
-{
-    if (j.is_string())
-        return tfl->newValue(j.get<std::string>());
-    if (j.is_number_integer())
-        return tfl->newValue(j.get<int64_t>());
-    if (j.is_number_float())
-        return tfl->newValue(j.get<double>());
-    if (j.is_boolean())
-        return tfl->newSmallValue(j.get<bool>());
-    if (j.is_null())
-        return {};
-    if (j.is_object()) {
-        auto subObject = tfl->newObject(j.size(), true);
-        for (auto& el : j.items())
-            subObject->addField(el.key(), jsonToMapget(tfl, el.value()));
-        return subObject;
-    }
-    if (j.is_array()) {
-        auto subArray = tfl->newArray(j.size(), true);
-        for (auto& el : j.items())
-            subArray->append(jsonToMapget(tfl, el.value()));
-        return subArray;
-    }
+using namespace mapget;
 
-    mapget::log().debug("Unhandled JSON type: {}", j.type_name());
-    return {};
+constexpr auto MANIFEST_FILENAME = "manifest.json";
+
+[[nodiscard]] int defaultParallelJobs()
+{
+    const auto hardwareThreads = static_cast<int>(std::thread::hardware_concurrency());
+    return std::max(static_cast<int>(0.33 * std::max(hardwareThreads, 1)), 2);
 }
 
-constexpr auto manifestFilename = "manifest.json";
+[[nodiscard]] bool looksLikeHttpUrl(std::string_view value)
+{
+    return value.starts_with("http://") || value.starts_with("https://");
+}
+
+[[nodiscard]] std::string trimmed(std::string value)
+{
+    while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())))
+        value.erase(value.begin());
+    while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())))
+        value.pop_back();
+    return value;
+}
+
+[[nodiscard]] std::string replaceAll(
+    std::string text,
+    std::string_view needle,
+    std::string_view replacement)
+{
+    if (needle.empty())
+        return text;
+
+    std::size_t pos = 0;
+    while ((pos = text.find(needle, pos)) != std::string::npos) {
+        text.replace(pos, needle.size(), replacement);
+        pos += replacement.size();
+    }
+    return text;
+}
+
+[[nodiscard]] std::string renderTemplate(
+    std::string const& input,
+    uint64_t tileId,
+    std::string_view layerId,
+    std::string_view baseUrl = {})
+{
+    auto result = replaceAll(input, "{tileId}", std::to_string(tileId));
+    result = replaceAll(result, "{layerId}", layerId);
+    if (!baseUrl.empty())
+        result = replaceAll(result, "{baseUrl}", baseUrl);
+    return result;
+}
+
+struct ParsedHttpUrl
+{
+    std::string origin;
+    std::string pathAndQuery;
+};
+
+[[nodiscard]] ParsedHttpUrl splitHttpUrl(std::string_view url)
+{
+    if (!looksLikeHttpUrl(url))
+        raise(fmt::format("Expected HTTP(S) URL, got `{}`.", url));
+
+    auto schemeEnd = url.find("://");
+    auto pathStart = url.find('/', schemeEnd + 3);
+    if (pathStart == std::string_view::npos)
+        return {std::string(url), "/"};
+    return {
+        std::string(url.substr(0, pathStart)),
+        std::string(url.substr(pathStart))};
+}
+
+[[nodiscard]] std::string joinUrlPrefixAndPath(
+    std::string_view baseUrl,
+    std::string_view relativePath)
+{
+    std::string result(baseUrl);
+    if (!result.empty() && result.back() == '/' &&
+        !relativePath.empty() && relativePath.front() == '/') {
+        result.pop_back();
+    }
+    else if (!result.empty() && result.back() != '/' &&
+             !relativePath.empty() && relativePath.front() != '/') {
+        result.push_back('/');
+    }
+    result.append(relativePath);
+    return result;
+}
+
+[[nodiscard]] bool hasGzipContentEncoding(std::string_view contentEncoding)
+{
+    if (contentEncoding.empty())
+        return false;
+
+    std::string normalized(contentEncoding);
+    std::ranges::transform(
+        normalized,
+        normalized.begin(),
+        [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return normalized.find("gzip") != std::string::npos;
+}
+
+[[nodiscard]] bool looksLikeGzip(std::string_view bytes)
+{
+    return bytes.size() >= 2 &&
+           static_cast<unsigned char>(bytes[0]) == 0x1f &&
+           static_cast<unsigned char>(bytes[1]) == 0x8b;
+}
+
+[[nodiscard]] std::optional<std::string> gunzip(std::string_view input)
+{
+    if (input.empty())
+        return std::string{};
+    if (input.size() > static_cast<std::size_t>(std::numeric_limits<uInt>::max()))
+        return std::nullopt;
+
+    z_stream stream{};
+    stream.next_in = reinterpret_cast<Bytef*>(const_cast<char*>(input.data()));
+    stream.avail_in = static_cast<uInt>(input.size());
+
+    if (inflateInit2(&stream, 16 + MAX_WBITS) != Z_OK)
+        return std::nullopt;
+
+    std::string output;
+    output.reserve(input.size() * 2);
+
+    char outBuffer[8192];
+    int inflateResult = Z_OK;
+    do {
+        stream.next_out = reinterpret_cast<Bytef*>(outBuffer);
+        stream.avail_out = sizeof(outBuffer);
+        inflateResult = inflate(&stream, Z_NO_FLUSH);
+        if (inflateResult != Z_OK && inflateResult != Z_STREAM_END) {
+            inflateEnd(&stream);
+            return std::nullopt;
+        }
+        output.append(outBuffer, sizeof(outBuffer) - stream.avail_out);
+    } while (inflateResult != Z_STREAM_END);
+
+    inflateEnd(&stream);
+    return output;
+}
+
+[[nodiscard]] std::optional<std::string> decodeResponseBody(
+    const drogon::HttpResponsePtr& response)
+{
+    if (!response)
+        return std::nullopt;
+
+    auto body = std::string_view(response->body().data(), response->body().size());
+    auto contentEncoding = response->getHeader("Content-Encoding");
+    if (contentEncoding.empty())
+        contentEncoding = response->getHeader("content-encoding");
+
+    const auto headerSaysGzip = hasGzipContentEncoding(contentEncoding);
+    const auto bodyLooksGzip = looksLikeGzip(body);
+    if (headerSaysGzip && !bodyLooksGzip)
+        return std::string(body);
+    if (!headerSaysGzip && !bodyLooksGzip)
+        return std::string(body);
+    return gunzip(body);
+}
+
+[[nodiscard]] std::string fetchHttpTextOnce(std::string const& url)
+{
+    auto parsedUrl = splitHttpUrl(url);
+
+    trantor::EventLoopThread loopThread("GeoJsonSourceHttpFetch");
+    loopThread.run();
+
+    auto client = drogon::HttpClient::newHttpClient(parsedUrl.origin, loopThread.getLoop());
+    auto request = drogon::HttpRequest::newHttpRequest();
+    request->setMethod(drogon::Get);
+    request->setPath(parsedUrl.pathAndQuery);
+    request->addHeader("Accept-Encoding", "gzip");
+
+    auto [result, response] = client->sendRequest(request);
+    if (result != drogon::ReqResult::Ok || !response) {
+        raise(fmt::format(
+            "Failed to fetch `{}`: [{}]",
+            url,
+            drogon::to_string_view(result)));
+    }
+    if (static_cast<int>(response->statusCode()) >= 300) {
+        raise(fmt::format(
+            "Failed to fetch `{}`: HTTP {}",
+            url,
+            static_cast<int>(response->statusCode())));
+    }
+
+    auto decodedBody = decodeResponseBody(response);
+    if (!decodedBody)
+        raise(fmt::format("Failed to decode response body from `{}`.", url));
+    return *decodedBody;
+}
+
+[[nodiscard]] std::optional<DataSourceInfo> loadConfiguredDataSourceInfo(
+    std::optional<nlohmann::json> const& inlineJson,
+    std::string const& location)
+{
+    if (inlineJson && !location.empty()) {
+        raise("`dataSourceInfoJson` and `dataSourceInfoLocation` cannot be used together.");
+    }
+
+    if (inlineJson) {
+        return DataSourceInfo::fromJson(*inlineJson);
+    }
+
+    if (location.empty())
+        return std::nullopt;
+
+    nlohmann::json infoJson;
+    if (looksLikeHttpUrl(location))
+        infoJson = parseStructuredDocument(fetchHttpTextOnce(location), location);
+    else
+        infoJson = loadStructuredDocumentFile(location);
+    return DataSourceInfo::fromJson(infoJson);
+}
+
+void ensureFeatureLayerInfoOnly(DataSourceInfo const& info, std::string_view context)
+{
+    for (auto const& [layerId, layerInfo] : info.layers_) {
+        if (layerInfo->type_ != LayerType::Features) {
+            raise(fmt::format(
+                "{} only supports feature layers, but `{}` is configured as type `{}`.",
+                context,
+                layerId,
+                nlohmann::json(layerInfo->type_).dump()));
+        }
+    }
+}
+
+void finalizeLoadedInfo(DataSourceInfo& info, std::string const& mapIdOverride)
+{
+    ensureFeatureLayerInfoOnly(info, "GeoJSON datasource");
+    info.maxParallelJobs_ = std::max(info.maxParallelJobs_, 1);
+    if (info.nodeId_.empty())
+        info.nodeId_ = generateNodeHexUuid();
+    if (!mapIdOverride.empty())
+        info.mapId_ = mapIdOverride;
+}
+
+[[nodiscard]] DataSourceInfo synthesizeFallbackInfo(std::string const& mapId)
+{
+    auto fallbackLayerJson = nlohmann::json::parse(R"json(
+    {
+      "featureTypes": [
+        {
+          "name": "AnyFeature",
+          "uniqueIdCompositions": [
+            [
+              {"partId": "tileId", "datatype": "U64"},
+              {"partId": "featureIndex", "datatype": "U32"}
+            ]
+          ]
+        }
+      ]
+    })json");
+
+    auto layerInfo = LayerInfo::fromJson(fallbackLayerJson, "GeoJsonAny");
+    DataSourceInfo info;
+    info.nodeId_ = generateNodeHexUuid();
+    info.mapId_ = mapId;
+    info.maxParallelJobs_ = defaultParallelJobs();
+    info.layers_.emplace(layerInfo->layerId_, std::move(layerInfo));
+    return info;
+}
+
+[[nodiscard]] std::string featureTypeNameForTile(const TileFeatureLayer::Ptr& tile)
+{
+    auto layerInfo = tile->layerInfo();
+    if (!layerInfo->featureTypes_.empty())
+        return layerInfo->featureTypes_.front().name_;
+
+    if (layerInfo->layerId_ == "GeoJsonAny")
+        return "AnyFeature";
+    return layerInfo->layerId_ + "Feature";
+}
+
+void fillGeoJsonTile(
+    const TileFeatureLayer::Ptr& tile,
+    std::string const& geoJsonBody,
+    bool withAttrLayers)
+{
+    tile->fromJson(
+        nlohmann::json::parse(geoJsonBody),
+        GeoJsonImportOptions{
+            .strict_ = false,
+            .fallbackFeatureType_ = featureTypeNameForTile(tile),
+            .objectPropertiesAsAttributeLayers_ = withAttrLayers,
+        });
+}
 
 }  // namespace
 
@@ -57,14 +326,7 @@ namespace mapget::geojsonsource
 
 nlohmann::json GeoJsonSource::createLayerInfoJson(const std::string& layerName)
 {
-    // Create feature type name from layer name (e.g., "Road" -> "RoadFeature")
-    std::string featureTypeName = layerName;
-    if (layerName != "GeoJsonAny") {
-        featureTypeName = layerName + "Feature";
-    } else {
-        featureTypeName = "AnyFeature";
-    }
-
+    std::string featureTypeName = layerName == "GeoJsonAny" ? "AnyFeature" : layerName + "Feature";
     return nlohmann::json::parse(fmt::format(R"json(
 {{
   "featureTypes": [
@@ -91,20 +353,14 @@ nlohmann::json GeoJsonSource::createLayerInfoJson(const std::string& layerName)
 
 bool GeoJsonSource::parseManifest()
 {
-    auto manifestPath = std::filesystem::path(inputDir_) / manifestFilename;
-    if (!std::filesystem::exists(manifestPath)) {
+    auto manifestPath = std::filesystem::path(inputDir_) / MANIFEST_FILENAME;
+    if (!std::filesystem::exists(manifestPath))
         return false;
-    }
 
     try {
-        std::ifstream manifestFile(manifestPath);
-        nlohmann::json manifestJson;
-        manifestFile >> manifestJson;
-
-        // Parse version (required)
+        auto manifestJson = loadStructuredDocumentFile(manifestPath.string());
         manifest_.version = manifestJson.value("version", 1);
 
-        // Parse metadata (optional)
         if (manifestJson.contains("metadata")) {
             auto& meta = manifestJson["metadata"];
             if (meta.contains("name"))
@@ -121,39 +377,32 @@ bool GeoJsonSource::parseManifest()
                 manifest_.metadata.license = meta["license"].get<std::string>();
         }
 
-        // Parse index (optional - if missing, will fall back to directory scan)
         if (manifestJson.contains("index")) {
             auto& index = manifestJson["index"];
-
-            // Default layer name
             manifest_.defaultLayer = index.value("defaultLayer", "GeoJsonAny");
 
-            // Parse files
             if (index.contains("files")) {
                 for (auto& [filename, fileInfo] : index["files"].items()) {
                     FileEntry entry;
                     entry.filename = filename;
 
                     if (fileInfo.is_object()) {
-                        // Full format: { "tileId": 123, "layer": "Road" }
                         entry.tileId = fileInfo.value("tileId", uint64_t{0});
                         entry.layer = fileInfo.value("layer", std::string{});
-                    } else if (fileInfo.is_number()) {
-                        // Short format: just the tile ID
+                    }
+                    else if (fileInfo.is_number()) {
                         entry.tileId = fileInfo.get<uint64_t>();
-                    } else {
+                    }
+                    else {
                         mapget::log().warn(
                             "Invalid file entry in manifest for '{}': expected object or number",
                             filename);
                         continue;
                     }
 
-                    // Use default layer if not specified
-                    if (entry.layer.empty()) {
+                    if (entry.layer.empty())
                         entry.layer = manifest_.defaultLayer;
-                    }
 
-                    // Validate file exists
                     auto filePath = std::filesystem::path(inputDir_) / filename;
                     if (!std::filesystem::exists(filePath)) {
                         mapget::log().warn(
@@ -170,10 +419,9 @@ bool GeoJsonSource::parseManifest()
         mapget::log().info(
             "Loaded manifest.json with {} file entries",
             manifest_.files.size());
-
         return true;
-
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e) {
         mapget::log().error("Failed to parse manifest.json: {}", e.what());
         return false;
     }
@@ -181,105 +429,111 @@ bool GeoJsonSource::parseManifest()
 
 void GeoJsonSource::initFromManifest()
 {
-    // Build layer coverage and file mapping from manifest entries
     for (const auto& entry : manifest_.files) {
-        // Track coverage per layer
         layerCoverage_[entry.layer].insert(entry.tileId);
-
-        // Map (tileId, layer) -> filename
-        TileLayerKey key{entry.tileId, entry.layer};
-        tileLayerToFile_[key] = entry.filename;
-
-        mapget::log().debug(
-            "Registered file '{}' -> tile {} in layer '{}'",
-            entry.filename, entry.tileId, entry.layer);
+        tileLayerToFile_[{entry.tileId, entry.layer}] = entry.filename;
     }
 
-    // Create LayerInfo for each discovered layer
     for (const auto& [layerName, tileIds] : layerCoverage_) {
-        auto layerJson = createLayerInfoJson(layerName);
-        auto layerInfo = mapget::LayerInfo::fromJson(layerJson, layerName);
-
-        // Add coverage entries
+        auto layerInfo = mapget::LayerInfo::fromJson(createLayerInfoJson(layerName), layerName);
         for (uint64_t tileId : tileIds) {
-            mapget::Coverage coverage({tileId, tileId, std::vector<bool>()});
-            layerInfo->coverage_.emplace_back(coverage);
+            layerInfo->coverage_.emplace_back(mapget::Coverage{tileId, tileId, {}});
         }
-
-        info_.layers_.emplace(layerName, layerInfo);
-        mapget::log().info(
-            "Layer '{}' initialized with {} tiles",
-            layerName, tileIds.size());
+        info_.layers_.emplace(layerName, std::move(layerInfo));
     }
 }
 
 void GeoJsonSource::initFromDirectory()
 {
-    // Legacy mode: scan for <tile-id>.geojson files
     const std::string defaultLayer = "GeoJsonAny";
-    auto layerJson = createLayerInfoJson(defaultLayer);
-    auto layerInfo = mapget::LayerInfo::fromJson(layerJson, defaultLayer);
+    auto layerInfo = mapget::LayerInfo::fromJson(createLayerInfoJson(defaultLayer), defaultLayer);
 
     for (const auto& file : std::filesystem::directory_iterator(inputDir_)) {
-        mapget::log().debug("Found file {}", file.path().string());
-        if (file.path().extension() == ".geojson") {
-            try {
-                auto tileId = static_cast<uint64_t>(std::stoull(file.path().stem()));
-                layerCoverage_[defaultLayer].insert(tileId);
+        if (file.path().extension() != ".geojson")
+            continue;
 
-                TileLayerKey key{tileId, defaultLayer};
-                tileLayerToFile_[key] = file.path().filename().string();
-
-                mapget::Coverage coverage({tileId, tileId, std::vector<bool>()});
-                layerInfo->coverage_.emplace_back(coverage);
-                mapget::log().debug("Added tile {}", tileId);
-            } catch (const std::exception& e) {
-                mapget::log().debug(
-                    "Skipping file '{}': filename is not a valid tile ID",
-                    file.path().filename().string());
-            }
+        try {
+            auto tileId = static_cast<uint64_t>(std::stoull(file.path().stem()));
+            layerCoverage_[defaultLayer].insert(tileId);
+            tileLayerToFile_[{tileId, defaultLayer}] = file.path().filename().string();
+            layerInfo->coverage_.emplace_back(mapget::Coverage{tileId, tileId, {}});
+        }
+        catch (const std::exception&) {
+            mapget::log().debug(
+                "Skipping file '{}': filename is not a valid tile ID",
+                file.path().filename().string());
         }
     }
 
-    info_.layers_.emplace(defaultLayer, layerInfo);
+    info_.layers_.emplace(defaultLayer, std::move(layerInfo));
 }
 
-GeoJsonSource::GeoJsonSource(const std::string& inputDir, bool withAttrLayers, const std::string& mapId)
-    : inputDir_(inputDir), withAttrLayers_(withAttrLayers)
+GeoJsonSource::GeoJsonSource(
+    const std::string& inputDir,
+    bool withAttrLayers,
+    const std::string& mapId)
+    : GeoJsonSource(
+        inputDir,
+        GeoJsonSourceOptions{
+            .withAttrLayers = withAttrLayers,
+            .mapId = mapId})
 {
-    // Compromise between performance and resource usage
-    info_.maxParallelJobs_ = std::max((int)(0.33*std::thread::hardware_concurrency()), 2);
-    info_.mapId_ = mapId.empty() ? mapNameFromUri(inputDir) : mapId;
+}
+
+GeoJsonSource::GeoJsonSource(std::string inputDir, GeoJsonSourceOptions options)
+    : inputDir_(std::move(inputDir)),
+      withAttrLayers_(options.withAttrLayers),
+      tilePathTemplate_(options.tilePathTemplate.empty() ? "{tileId}.geojson" : options.tilePathTemplate)
+{
+    info_.maxParallelJobs_ = defaultParallelJobs();
+    info_.mapId_ = options.mapId.empty() ? mapNameFromUri(inputDir_) : options.mapId;
     info_.nodeId_ = generateNodeHexUuid();
 
-    // Try to load manifest.json first
-    hasManifest_ = parseManifest();
+    if (auto loadedInfo = loadConfiguredDataSourceInfo(
+            options.dataSourceInfoJson,
+            options.dataSourceInfoLocation)) {
+        info_ = std::move(*loadedInfo);
+        finalizeLoadedInfo(info_, options.mapId);
+        usesTemplatePaths_ = true;
 
-    if (hasManifest_) {
-        if (!manifest_.files.empty()) {
-            initFromManifest();
-        } else {
+        if (std::filesystem::exists(std::filesystem::path(inputDir_) / MANIFEST_FILENAME)) {
             mapget::log().info(
-                "manifest.json found but has no index/files section - no tiles available");
+                "GeoJsonFolder is using explicit dataSourceInfo; manifest.json in '{}' is ignored.",
+                inputDir_);
         }
-    } else {
-        mapget::log().warn(
-            "No manifest.json found in '{}'. "
-            "Using deprecated legacy mode with filename-based tile ID detection. "
-            "Legacy mode will be removed in a future release. "
-            "Please add a manifest.json for file mapping and multi-layer support.",
-            inputDir);
-        initFromDirectory();
+    }
+    else {
+        if (!options.tilePathTemplate.empty()) {
+            mapget::log().warn(
+                "GeoJsonFolder ignores `tilePathTemplate` without explicit dataSourceInfo. "
+                "Using manifest or legacy filename discovery instead.");
+        }
+
+        hasManifest_ = parseManifest();
+        if (hasManifest_) {
+            if (!manifest_.files.empty()) {
+                initFromManifest();
+            }
+            else {
+                mapget::log().info(
+                    "manifest.json found but has no index/files section - no tiles available");
+            }
+        }
+        else {
+            mapget::log().warn(
+                "No manifest.json found in '{}'. "
+                "Using deprecated legacy mode with filename-based tile ID detection. "
+                "Provide `dataSourceInfo` for template-based loading.",
+                inputDir_);
+            initFromDirectory();
+        }
     }
 
-    // Log summary
-    size_t totalTiles = 0;
-    for (const auto& [layer, tileIds] : layerCoverage_) {
-        totalTiles += tileIds.size();
-    }
     mapget::log().info(
-        "GeoJsonSource initialized: {} layers, {} total tile entries",
-        info_.layers_.size(), totalTiles);
+        "GeoJsonFolder initialized: mapId='{}', layers={}, mode={}",
+        info_.mapId_,
+        info_.layers_.size(),
+        usesTemplatePaths_ ? "template" : hasManifest_ ? "manifest" : "legacy");
 }
 
 mapget::DataSourceInfo GeoJsonSource::info()
@@ -287,144 +541,220 @@ mapget::DataSourceInfo GeoJsonSource::info()
     return info_;
 }
 
-void GeoJsonSource::fill(const mapget::TileFeatureLayer::Ptr& tile)
+std::string GeoJsonSource::resolveTilePath(uint64_t tileId, std::string_view layerId) const
 {
-    using namespace mapget;
+    auto rendered = renderTemplate(tilePathTemplate_, tileId, layerId);
+    std::filesystem::path path(rendered);
+    if (path.is_absolute())
+        return path.string();
+    return (std::filesystem::path(inputDir_) / path).string();
+}
 
-    auto tileId = tile->tileId().value_;
-    auto layerName = tile->layerInfo()->layerId_;
+std::string GeoJsonSource::readTileBody(uint64_t tileId, std::string_view layerId) const
+{
+    if (usesTemplatePaths_) {
+        auto path = resolveTilePath(tileId, layerId);
+        std::ifstream geojsonFile(path);
+        if (!geojsonFile)
+            raise(fmt::format("Failed to open GeoJSON file `{}`.", path));
+        std::ostringstream buffer;
+        buffer << geojsonFile.rdbuf();
+        return buffer.str();
+    }
 
-    mapget::log().debug("Filling tile {} for layer '{}'", tileId, layerName);
-
-    // Look up the file for this (tileId, layer) combination
-    TileLayerKey key{tileId, layerName};
+    TileLayerKey key{tileId, std::string(layerId)};
     auto fileIt = tileLayerToFile_.find(key);
     if (fileIt == tileLayerToFile_.end()) {
-        mapget::log().error(
-            "No file registered for tile {} in layer '{}'",
-            tileId, layerName);
-        return;
+        raise(fmt::format(
+            "No GeoJSON file registered for tile {} in layer `{}`.",
+            tileId,
+            layerId));
     }
 
-    // All features share the same tile id
-    tile->setIdPrefix({{"tileId", static_cast<int64_t>(tileId)}});
-
-    // Build the full path
     auto path = (std::filesystem::path(inputDir_) / fileIt->second).string();
-
-    mapget::log().debug("Opening: {}", path);
-
     std::ifstream geojsonFile(path);
-    if (!geojsonFile) {
-        mapget::log().error("Failed to open file: {}", path);
-        return;
+    if (!geojsonFile)
+        raise(fmt::format("Failed to open GeoJSON file `{}`.", path));
+
+    std::ostringstream buffer;
+    buffer << geojsonFile.rdbuf();
+    return buffer.str();
+}
+
+void GeoJsonSource::fill(const mapget::TileFeatureLayer::Ptr& tile)
+{
+    try {
+        fillGeoJsonTile(
+            tile,
+            readTileBody(tile->tileId().value_, tile->layerInfo()->layerId_),
+            withAttrLayers_);
     }
-
-    nlohmann::json geojsonData;
-    geojsonFile >> geojsonData;
-
-    mapget::log().debug("Processing {} features...", geojsonData["features"].size());
-
-    // Get the feature type name for this layer
-    std::string featureTypeName = (layerName == "GeoJsonAny") ? "AnyFeature" : (layerName + "Feature");
-
-    // Iterate over each feature in the GeoJSON data
-    int featureId = 0;
-    for (auto& feature_data : geojsonData["features"]) {
-        // Create a new feature
-        auto feature = tile->newFeature(featureTypeName, {{"featureIndex", featureId}});
-        featureId++;
-
-        // Parse geometry data (recursive lambda to support GeometryCollection)
-        std::function<void(nlohmann::json const&)> addGeometry;
-        addGeometry = [&](nlohmann::json const& geom) {
-            if (!geom.is_object() || !geom.contains("type"))
-                return;
-            auto const type = geom["type"].get<std::string>();
-            if (type == "Point") {
-                auto const& c = geom["coordinates"];
-                feature->addPoint({c[0], c[1]});
-            }
-            else if (type == "MultiPoint") {
-                auto points = feature->geom()->newGeometry(GeomType::Points, geom["coordinates"].size());
-                for (auto const& c : geom["coordinates"])
-                    points->append({c[0], c[1]});
-            }
-            else if (type == "LineString") {
-                auto line = feature->geom()->newGeometry(GeomType::Line, geom["coordinates"].size());
-                for (auto const& c : geom["coordinates"])
-                    line->append({c[0], c[1]});
-            }
-            else if (type == "MultiLineString") {
-                for (auto const& coords : geom["coordinates"]) {
-                    auto line = feature->geom()->newGeometry(GeomType::Line, coords.size());
-                    for (auto const& c : coords)
-                        line->append({c[0], c[1]});
-                }
-            }
-            else if (type == "Polygon") {
-                if (!geom["coordinates"].empty()) {
-                    auto const& ring = geom["coordinates"][0];
-                    auto poly = feature->geom()->newGeometry(GeomType::Polygon, ring.size());
-                    for (auto const& c : ring)
-                        poly->append({c[0], c[1]});
-                }
-            }
-            else if (type == "MultiPolygon") {
-                for (auto const& polygon : geom["coordinates"]) {
-                    if (!polygon.empty()) {
-                        auto const& ring = polygon[0];
-                        auto poly = feature->geom()->newGeometry(GeomType::Polygon, ring.size());
-                        for (auto const& c : ring)
-                            poly->append({c[0], c[1]});
-                    }
-                }
-            }
-            else if (type == "GeometryCollection") {
-                for (auto const& child : geom["geometries"])
-                    addGeometry(child);
-            }
-        };
-        addGeometry(feature_data["geometry"]);
-
-        // Add top-level properties as attributes
-        for (auto& property : feature_data["properties"].items()) {
-
-            // Always emit scalar properties
-            if (!property.value().is_object()) {
-                feature->attributes()->addField(property.key(), jsonToMapget(tile, property.value()));
-                continue;
-            }
-
-            // Emit layers conditionally
-            if (!withAttrLayers_)
-                continue;
-
-            // If the property value is an object, add an attribute layer
-            auto attrLayer = feature->attributeLayers()->newLayer(property.key());
-            for (auto& attr : property.value().items()) {
-                auto attribute = attrLayer->newAttribute(attr.key());
-                attribute->addField(attr.key(), jsonToMapget(tile, attr.value()));
-
-                // Check if the value is an object and contains a "_direction" field
-                if (attr.value().is_object() && attr.value().contains("_direction")) {
-                    std::string dir = attr.value()["_direction"];
-                    auto validDir = dir == "POSITIVE" ? Validity::Positive :
-                                    dir == "NEGATIVE" ? Validity::Negative :
-                                    (dir == "COMPLETE" || dir == "BOTH") ? Validity::Both :
-                                                        Validity::Empty;
-                    attribute->validity()->newDirection(validDir);
-                }
-            }
-        }
+    catch (const std::exception& e) {
+        tile->setError(e.what());
+        mapget::log().error(
+            "GeoJsonFolder failed to fill tile {} for layer '{}': {}",
+            tile->tileId().value_,
+            tile->layerInfo()->layerId_,
+            e.what());
     }
-
-    mapget::log().debug("            done!");
 }
 
 void GeoJsonSource::fill(mapget::TileSourceDataLayer::Ptr const&)
 {
-    // Do nothing...
+    // This datasource only serves feature tiles.
+}
+
+struct GeoJsonEndpointSource::Impl
+{
+    struct ClientPool
+    {
+        std::vector<drogon::HttpClientPtr> clients;
+        std::size_t nextClient = 0;
+    };
+
+    explicit Impl(int clientCount)
+        : clientCount_(std::max(clientCount, 1))
+    {
+        loopThread_ = std::make_unique<trantor::EventLoopThread>("GeoJsonEndpointSource");
+        loopThread_->run();
+    }
+
+    [[nodiscard]] drogon::HttpClientPtr acquireClient(std::string const& origin)
+    {
+        std::lock_guard lock(mutex_);
+        auto& pool = pools_[origin];
+        if (pool.clients.empty()) {
+            pool.clients.reserve(clientCount_);
+            for (int i = 0; i < clientCount_; ++i) {
+                pool.clients.push_back(drogon::HttpClient::newHttpClient(origin, loopThread_->getLoop()));
+            }
+        }
+        auto client = pool.clients[pool.nextClient % pool.clients.size()];
+        ++pool.nextClient;
+        return client;
+    }
+
+    int clientCount_ = 1;
+    std::unique_ptr<trantor::EventLoopThread> loopThread_;
+    std::mutex mutex_;
+    std::unordered_map<std::string, ClientPool> pools_;
+};
+
+GeoJsonEndpointSource::GeoJsonEndpointSource(GeoJsonEndpointSourceOptions options)
+    : baseUrl_(trimmed(options.baseUrl)),
+      tileUrlTemplate_(options.tileUrlTemplate.empty() ? "{tileId}.geojson" : options.tileUrlTemplate),
+      withAttrLayers_(options.withAttrLayers)
+{
+    if (baseUrl_.empty())
+        raise("GeoJsonEndpoint requires a non-empty `baseUrl`.");
+
+    info_.maxParallelJobs_ = defaultParallelJobs();
+    info_.mapId_ = options.mapId.empty() ? mapNameFromUri(baseUrl_) : options.mapId;
+    info_.nodeId_ = generateNodeHexUuid();
+
+    if (auto loadedInfo = loadConfiguredDataSourceInfo(
+            options.dataSourceInfoJson,
+            options.dataSourceInfoLocation)) {
+        info_ = std::move(*loadedInfo);
+        finalizeLoadedInfo(info_, options.mapId);
+    }
+    else {
+        info_ = synthesizeFallbackInfo(info_.mapId_);
+        if (!options.mapId.empty())
+            info_.mapId_ = options.mapId;
+
+        mapget::log().warn(
+            "No `dataSourceInfo` configured for GeoJsonEndpoint '{}'. "
+            "Only `GeoJsonAny` will be advertised, coverage stays empty, "
+            "and conversion will run in best-effort mode.",
+            baseUrl_);
+    }
+
+    impl_ = std::make_unique<Impl>(std::max(info_.maxParallelJobs_, 1));
+
+    mapget::log().info(
+        "GeoJsonEndpoint initialized: mapId='{}', layers={}, baseUrl='{}'",
+        info_.mapId_,
+        info_.layers_.size(),
+        baseUrl_);
+}
+
+GeoJsonEndpointSource::~GeoJsonEndpointSource() = default;
+
+mapget::DataSourceInfo GeoJsonEndpointSource::info()
+{
+    return info_;
+}
+
+std::string GeoJsonEndpointSource::renderTileUrl(uint64_t tileId, std::string_view layerId) const
+{
+    auto rendered = renderTemplate(tileUrlTemplate_, tileId, layerId, baseUrl_);
+    if (looksLikeHttpUrl(rendered))
+        return rendered;
+    return joinUrlPrefixAndPath(baseUrl_, rendered);
+}
+
+std::string GeoJsonEndpointSource::fetchTileBody(uint64_t tileId, std::string_view layerId) const
+{
+    auto url = renderTileUrl(tileId, layerId);
+    auto parsedUrl = splitHttpUrl(url);
+    auto client = impl_->acquireClient(parsedUrl.origin);
+
+    auto request = drogon::HttpRequest::newHttpRequest();
+    request->setMethod(drogon::Get);
+    request->setPath(parsedUrl.pathAndQuery);
+    request->addHeader("Accept-Encoding", "gzip");
+
+    auto [result, response] = client->sendRequest(request);
+    if (result != drogon::ReqResult::Ok || !response) {
+        raise(fmt::format(
+            "Failed to fetch tile `{}` for layer `{}` from `{}`: [{}]",
+            tileId,
+            layerId,
+            url,
+            drogon::to_string_view(result)));
+    }
+    if (static_cast<int>(response->statusCode()) >= 300) {
+        raise(fmt::format(
+            "Failed to fetch tile `{}` for layer `{}` from `{}`: HTTP {}",
+            tileId,
+            layerId,
+            url,
+            static_cast<int>(response->statusCode())));
+    }
+
+    auto decodedBody = decodeResponseBody(response);
+    if (!decodedBody) {
+        raise(fmt::format(
+            "Failed to decode tile response for `{}` / `{}` from `{}`.",
+            tileId,
+            layerId,
+            url));
+    }
+    return *decodedBody;
+}
+
+void GeoJsonEndpointSource::fill(const mapget::TileFeatureLayer::Ptr& tile)
+{
+    try {
+        fillGeoJsonTile(
+            tile,
+            fetchTileBody(tile->tileId().value_, tile->layerInfo()->layerId_),
+            withAttrLayers_);
+    }
+    catch (const std::exception& e) {
+        tile->setError(e.what());
+        mapget::log().error(
+            "GeoJsonEndpoint failed to fill tile {} for layer '{}': {}",
+            tile->tileId().value_,
+            tile->layerInfo()->layerId_,
+            e.what());
+    }
+}
+
+void GeoJsonEndpointSource::fill(mapget::TileSourceDataLayer::Ptr const&)
+{
+    // This datasource only serves feature tiles.
 }
 
 }  // namespace mapget::geojsonsource

--- a/libs/geojsonsource/src/geojsonsource.cpp
+++ b/libs/geojsonsource/src/geojsonsource.cpp
@@ -35,9 +35,29 @@ constexpr auto MANIFEST_FILENAME = "manifest.json";
     return std::max(static_cast<int>(0.33 * std::max(hardwareThreads, 1)), 2);
 }
 
+[[nodiscard]] std::string_view cleartextWebScheme()
+{
+    static constexpr char scheme[] = {'h', 't', 't', 'p', '\0'};
+    return {scheme, 4};
+}
+
+[[nodiscard]] std::string_view tlsWebScheme()
+{
+    static constexpr char scheme[] = {'h', 't', 't', 'p', 's', '\0'};
+    return {scheme, 5};
+}
+
+[[nodiscard]] bool hasUrlScheme(std::string_view value, std::string_view scheme)
+{
+    constexpr std::string_view delimiter = "://";
+    return value.size() > scheme.size() + delimiter.size() &&
+           value.compare(0, scheme.size(), scheme) == 0 &&
+           value.compare(scheme.size(), delimiter.size(), delimiter) == 0;
+}
+
 [[nodiscard]] bool looksLikeHttpUrl(std::string_view value)
 {
-    return value.starts_with("http://") || value.starts_with("https://");
+    return hasUrlScheme(value, cleartextWebScheme()) || hasUrlScheme(value, tlsWebScheme());
 }
 
 [[nodiscard]] std::string trimmed(std::string value)

--- a/libs/http-service/src/cli.cpp
+++ b/libs/http-service/src/cli.cpp
@@ -20,6 +20,9 @@
 #include <nlohmann/json.hpp>
 #include <filesystem>
 #include <fstream>
+#include <algorithm>
+#include <cctype>
+#include <string_view>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -102,11 +105,162 @@ nlohmann::json geoJsonFolderSchema()
                 {"title", "With Attribute Layers"},
                 {"description", "Convert nested GeoJSON property objects to mapget attribute layers. Default: true."},
                 {"default", true}
+            }},
+            {"tilePathTemplate", {
+                {"type", "string"},
+                {"title", "Tile Path Template"},
+                {"description", "Relative path template used with explicit dataSourceInfo, e.g. `{layerId}/{tileId}.geojson`."}
+            }},
+            {"dataSourceInfo", {
+                {"title", "Datasource Info"},
+                {"description", "Inline datasource info object, local YAML/JSON file path, or HTTP(S) URL."},
+                {"oneOf", nlohmann::json::array({
+                    nlohmann::json{{"type", "string"}},
+                    nlohmann::json{{"type", "object"}}
+                })}
             }}
         }},
         {"required", nlohmann::json::array({"folder"})},
         {"additionalProperties", false}
     };
+}
+
+nlohmann::json geoJsonEndpointSchema()
+{
+    return {
+        {"type", "object"},
+        {"properties", {
+            {"baseUrl", {
+                {"type", "string"},
+                {"title", "Base URL"},
+                {"description", "Base HTTP(S) URL used to fetch GeoJSON tiles."}
+            }},
+            {"mapId", {
+                {"type", "string"},
+                {"title", "Map ID"},
+                {"description", "Custom map identifier. If not provided, derived from the baseUrl."}
+            }},
+            {"withAttrLayers", {
+                {"type", "boolean"},
+                {"title", "With Attribute Layers"},
+                {"description", "Convert nested GeoJSON property objects to mapget attribute layers. Default: true."},
+                {"default", true}
+            }},
+            {"tileUrlTemplate", {
+                {"type", "string"},
+                {"title", "Tile URL Template"},
+                {"description", "URL or relative path template used to fetch tiles, e.g. `{layerId}/{tileId}.geojson`."}
+            }},
+            {"dataSourceInfo", {
+                {"title", "Datasource Info"},
+                {"description", "Inline datasource info object, local YAML/JSON file path, or HTTP(S) URL."},
+                {"oneOf", nlohmann::json::array({
+                    nlohmann::json{{"type", "string"}},
+                    nlohmann::json{{"type", "object"}}
+                })}
+            }}
+        }},
+        {"required", nlohmann::json::array({"baseUrl"})},
+        {"additionalProperties", false}
+    };
+}
+
+[[nodiscard]] bool looksLikeHttpUrl(std::string_view value)
+{
+    return value.starts_with("http://") || value.starts_with("https://");
+}
+
+[[nodiscard]] std::string trimCopy(std::string value)
+{
+    auto isWhitespace = [](unsigned char ch) { return std::isspace(ch) != 0; };
+    value.erase(value.begin(), std::find_if(value.begin(), value.end(), [&](char ch) {
+        return !isWhitespace(static_cast<unsigned char>(ch));
+    }));
+    value.erase(std::find_if(value.rbegin(), value.rend(), [&](char ch) {
+        return !isWhitespace(static_cast<unsigned char>(ch));
+    }).base(), value.end());
+    return value;
+}
+
+[[nodiscard]] std::filesystem::path configDirectory()
+{
+    if (auto configPath = DataSourceConfigService::get().getConfigFilePath()) {
+        return std::filesystem::path(*configPath).parent_path();
+    }
+    return std::filesystem::current_path();
+}
+
+void applyStructuredDocumentOption(
+    const YAML::Node& config,
+    std::optional<nlohmann::json>& inlineJsonOut,
+    std::string& locationOut)
+{
+    if (!config) {
+        return;
+    }
+
+    if (config.IsMap() || config.IsSequence()) {
+        inlineJsonOut = yamlToJson(config, false);
+        return;
+    }
+
+    if (!config.IsScalar()) {
+        throw std::runtime_error("`dataSourceInfo` must be a mapping or scalar string.");
+    }
+
+    auto value = trimCopy(config.as<std::string>());
+    if (value.empty()) {
+        return;
+    }
+
+    if (value.front() == '{' || value.front() == '[') {
+        inlineJsonOut = parseStructuredDocument(value, "inline dataSourceInfo");
+        return;
+    }
+
+    if (looksLikeHttpUrl(value)) {
+        locationOut = value;
+        return;
+    }
+
+    auto path = std::filesystem::path(value);
+    if (path.is_relative())
+        path = configDirectory() / path;
+    locationOut = path.lexically_normal().string();
+}
+
+[[nodiscard]] geojsonsource::GeoJsonSourceOptions makeGeoJsonFolderOptions(YAML::Node const& config)
+{
+    geojsonsource::GeoJsonSourceOptions options;
+    if (auto withAttributeLayersNode = config["withAttrLayers"])
+        options.withAttrLayers = withAttributeLayersNode.as<bool>();
+    if (auto mapIdNode = config["mapId"])
+        options.mapId = mapIdNode.as<std::string>();
+    if (auto tilePathTemplateNode = config["tilePathTemplate"])
+        options.tilePathTemplate = tilePathTemplateNode.as<std::string>();
+    applyStructuredDocumentOption(
+        config["dataSourceInfo"],
+        options.dataSourceInfoJson,
+        options.dataSourceInfoLocation);
+    return options;
+}
+
+[[nodiscard]] geojsonsource::GeoJsonEndpointSourceOptions makeGeoJsonEndpointOptions(YAML::Node const& config)
+{
+    geojsonsource::GeoJsonEndpointSourceOptions options;
+    if (auto baseUrlNode = config["baseUrl"])
+        options.baseUrl = baseUrlNode.as<std::string>();
+    if (auto withAttributeLayersNode = config["withAttrLayers"])
+        options.withAttrLayers = withAttributeLayersNode.as<bool>();
+    if (auto mapIdNode = config["mapId"])
+        options.mapId = mapIdNode.as<std::string>();
+    if (auto tileUrlTemplateNode = config["tileUrlTemplate"])
+        options.tileUrlTemplate = tileUrlTemplateNode.as<std::string>();
+    applyStructuredDocumentOption(
+        config["dataSourceInfo"],
+        options.dataSourceInfoJson,
+        options.dataSourceInfoLocation);
+    return options;
 }
 
 class ConfigYAML : public CLI::Config
@@ -240,17 +394,22 @@ void registerDefaultDatasourceTypes() {
         "GeoJsonFolder",
         [](YAML::Node const& config) -> DataSource::Ptr {
             if (auto folder = config["folder"]) {
-                bool withAttributeLayers = true;
-                if (auto withAttributeLayersNode = config["withAttrLayers"])
-                    withAttributeLayers = withAttributeLayersNode.as<bool>();
-                std::string mapId;
-                if (auto mapIdNode = config["mapId"])
-                    mapId = mapIdNode.as<std::string>();
-                return std::make_shared<geojsonsource::GeoJsonSource>(folder.as<std::string>(), withAttributeLayers, mapId);
+                return std::make_shared<geojsonsource::GeoJsonSource>(
+                    folder.as<std::string>(),
+                    makeGeoJsonFolderOptions(config));
             }
             throw std::runtime_error("Missing `folder` field.");
         },
         geoJsonFolderSchema());
+    service.registerDataSourceType(
+        "GeoJsonEndpoint",
+        [](YAML::Node const& config) -> DataSource::Ptr {
+            auto options = makeGeoJsonEndpointOptions(config);
+            if (options.baseUrl.empty())
+                throw std::runtime_error("Missing `baseUrl` field.");
+            return std::make_shared<geojsonsource::GeoJsonEndpointSource>(std::move(options));
+        },
+        geoJsonEndpointSchema());
 }
 
 void loadConfigSchemaPatch(const std::string& schemaPath)

--- a/libs/http-service/src/cli.cpp
+++ b/libs/http-service/src/cli.cpp
@@ -167,7 +167,15 @@ nlohmann::json geoJsonEndpointSchema()
 
 [[nodiscard]] bool looksLikeHttpUrl(std::string_view value)
 {
-    return value.starts_with("http://") || value.starts_with("https://");
+    static constexpr char cleartextScheme[] = {'h', 't', 't', 'p', '\0'};
+    static constexpr char tlsScheme[] = {'h', 't', 't', 'p', 's', '\0'};
+    constexpr std::string_view delimiter = "://";
+    auto hasScheme = [&](std::string_view scheme) {
+        return value.size() > scheme.size() + delimiter.size() &&
+               value.compare(0, scheme.size(), scheme) == 0 &&
+               value.compare(scheme.size(), delimiter.size(), delimiter) == 0;
+    };
+    return hasScheme({cleartextScheme, 4}) || hasScheme({tlsScheme, 5});
 }
 
 [[nodiscard]] std::string trimCopy(std::string value)

--- a/libs/http-service/src/config-handler.cpp
+++ b/libs/http-service/src/config-handler.cpp
@@ -201,11 +201,26 @@ void HttpService::Impl::handlePostConfigRequest(
 
     configFile.close();
     log().trace("Writing new config.");
-    state->wroteConfig = true;
     if (auto configFilePath = DataSourceConfigService::get().getConfigFilePath()) {
         std::ofstream newConfigFile(*configFilePath);
+        if (!newConfigFile) {
+            auto resp = drogon::HttpResponse::newHttpResponse();
+            resp->setStatusCode(drogon::k500InternalServerError);
+            resp->setContentTypeCode(drogon::CT_TEXT_PLAIN);
+            resp->setBody(std::string("Error applying the configuration: failed to open ") + *configFilePath);
+            state->done = true;
+            state->callback(resp);
+            state->subscription.reset();
+            return;
+        }
+
         newConfigFile << yamlConfig;
+        newConfigFile.flush();
         newConfigFile.close();
+
+        // Ignore watcher callbacks until the rewritten file has been fully flushed.
+        state->wroteConfig = true;
+        DataSourceConfigService::get().loadConfig(*configFilePath, false);
     }
 
     std::thread([weak = state->weak_from_this()]() {
@@ -226,4 +241,3 @@ void HttpService::Impl::handlePostConfigRequest(
 }
 
 }  // namespace mapget
-

--- a/libs/model/CMakeLists.txt
+++ b/libs/model/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(mapget-model STATIC
   include/mapget/model/stringpool.h
   include/mapget/model/layer.h
   include/mapget/model/featurelayer.h
+  include/mapget/model/geojson-import.h
+  include/mapget/model/json-compare.h
   include/mapget/model/info.h
   include/mapget/model/feature.h
   include/mapget/model/attr.h
@@ -29,6 +31,8 @@ add_library(mapget-model STATIC
   src/stringpool.cpp
   src/layer.cpp
   src/featurelayer.cpp
+  src/geojson-import.cpp
+  src/json-compare.cpp
   src/info.cpp
   src/feature.cpp
   src/attr.cpp

--- a/libs/model/include/mapget/model/featureid.h
+++ b/libs/model/include/mapget/model/featureid.h
@@ -17,7 +17,10 @@ using Object = simfil::Object;
 using Array = simfil::Array;
 
 /**
- * Unique feature ID
+ * Canonical feature identifier tied to a layer's configured id compositions.
+ *
+ * The string form is dot-separated and may elide a shared tile prefix when the
+ * backing storage uses `useCommonTilePrefix_`.
  */
 class FeatureId : public simfil::MandatoryDerivedModelNodeBase<TileFeatureLayer>
 {
@@ -36,6 +39,7 @@ public:
     /** Get all id-part key-value-pairs (including the common prefix). */
     [[nodiscard]] KeyValueViewPairs keyValuePairs() const;
 
+    /** Compact serialized representation of a feature id node. */
     struct Data {
         MODEL_COLUMN_TYPE(8);
 
@@ -76,5 +80,24 @@ protected:
     std::vector<simfil::StringId> partNames_;
     std::vector<uint32_t> visibleValueIndices_;
 };
+
+/** Parsed representation of a canonical feature-id string. */
+struct ParsedFeatureId
+{
+    std::string typeId_;
+    KeyValuePairs keyValuePairs_;
+    uint8_t idCompositionIndex_ = 0;
+};
+
+/**
+ * Parse a canonical dot-separated feature-id string as emitted by FeatureId::toString().
+ * String-valued id parts are percent-unescaped before datatype validation.
+ * Ambiguous matches are rejected so callers can resolve a single composition.
+ */
+bool parseFeatureIdString(
+    std::string_view featureId,
+    LayerInfo const& layerInfo,
+    ParsedFeatureId& result,
+    std::string* error = nullptr);
 
 }

--- a/libs/model/include/mapget/model/featureid.h
+++ b/libs/model/include/mapget/model/featureid.h
@@ -48,12 +48,6 @@ public:
     /** Get all id-part key-value-pairs (including the common prefix). */
     [[nodiscard]] KeyValueViewPairs keyValuePairs() const;
 
-    /** Export local references as canonical strings and external references as `{id, mapId}` objects. */
-    [[nodiscard]] nlohmann::json toJson() const override;
-
-    /** Materialize the JSON reference shape as model nodes for relation/validity export. */
-    [[nodiscard]] ModelNode::Ptr jsonReferenceNode() const;
-
     /** Compact serialized representation of a feature id node. */
     struct Data {
         MODEL_COLUMN_TYPE(12);

--- a/libs/model/include/mapget/model/featureid.h
+++ b/libs/model/include/mapget/model/featureid.h
@@ -36,17 +36,33 @@ public:
     /** Get the feature ID's type id. */
     [[nodiscard]] std::string_view typeId() const;
 
+    /** Get the effective map id referenced by this feature id. */
+    [[nodiscard]] std::string mapId() const;
+
+    /**
+     * Get the explicitly stored external map id for detached references.
+     * Returns nullopt when the reference points into the current tile's map.
+     */
+    [[nodiscard]] std::optional<std::string_view> externalMapId() const;
+
     /** Get all id-part key-value-pairs (including the common prefix). */
     [[nodiscard]] KeyValueViewPairs keyValuePairs() const;
 
+    /** Export local references as canonical strings and external references as `{id, mapId}` objects. */
+    [[nodiscard]] nlohmann::json toJson() const override;
+
+    /** Materialize the JSON reference shape as model nodes for relation/validity export. */
+    [[nodiscard]] ModelNode::Ptr jsonReferenceNode() const;
+
     /** Compact serialized representation of a feature id node. */
     struct Data {
-        MODEL_COLUMN_TYPE(8);
+        MODEL_COLUMN_TYPE(12);
 
         bool useCommonTilePrefix_ = false;
         uint8_t idCompositionIndex_ = 0;
         simfil::StringId typeId_ = 0;
         simfil::ArrayIndex idPartValues_ = simfil::InvalidArrayIndex;
+        simfil::StringId extMapId_ = simfil::StringPool::Empty;
     };
 
 protected:

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -166,10 +166,13 @@ public:
      * Create a new feature id. Use this function to create a reference to another
      * feature. The created feature id will not use the common feature id prefix from
      * this tile feature layer, since the reference may be to a feature stored in a
-     * different tile.
+     * different tile or map. When `externalMapId` is set to another map, the detached
+     * reference keeps that map id for binary serialization and JSON export.
      */
     model_ptr<FeatureId> newFeatureId(
-        std::string_view const& typeId, KeyValueViewPairs const& featureIdParts);
+        std::string_view const& typeId,
+        KeyValueViewPairs const& featureIdParts,
+        std::optional<std::string_view> externalMapId = std::nullopt);
 
     /**
      * Create a new relation. Use this function to create a named reference to another

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -17,6 +17,7 @@
 #include "stringpool.h"
 #include "layer.h"
 #include "sourceinfo.h"
+#include "geojson-import.h"
 #include "feature.h"
 #include "attrlayer.h"
 #include "relation.h"
@@ -273,6 +274,9 @@ public:
     /** Convert to (Geo-) JSON. */
     nlohmann::json toJson() const override;
 
+    /** Import a mapget-flavoured or best-effort GeoJSON feature collection into this tile. */
+    void fromJson(nlohmann::json const& json, GeoJsonImportOptions const& options = {});
+
     /**
      * Inspect or replace the optional tile-level GLB attachment without
      * inlining payload bytes.
@@ -307,6 +311,8 @@ public:
 
     /** Optional staged-loading index (0-based) for this feature tile. */
     [[nodiscard]] std::optional<uint32_t> stage() const override;
+
+    /** Store or clear the tile-stage marker without affecting contained geometries. */
     void setStage(std::optional<uint32_t> stage) override;
 
     /**

--- a/libs/model/include/mapget/model/geojson-import.h
+++ b/libs/model/include/mapget/model/geojson-import.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include <nlohmann/json_fwd.hpp>
+
+namespace mapget
+{
+
+class TileFeatureLayer;
+
+/**
+ * Controls whether GeoJSON import behaves like a strict mapget roundtrip
+ * reader or as a permissive adapter for generic external GeoJSON.
+ */
+struct GeoJsonImportOptions
+{
+    /** Require mapget-style structure and reject lossy or ambiguous input. */
+    bool strict_ = true;
+
+    /** Feature type to assume when the GeoJSON feature does not carry `typeId`. */
+    std::optional<std::string> fallbackFeatureType_;
+
+    /**
+     * In best-effort mode, treat object-valued entries under `properties`
+     * as attribute-layer payloads instead of plain JSON attributes.
+     */
+    bool objectPropertiesAsAttributeLayers_ = false;
+};
+
+/**
+ * Import a FeatureCollection into an empty TileFeatureLayer.
+ *
+ * Depending on `options`, this either expects mapget's JSON profile or
+ * performs best-effort adaptation from generic GeoJSON.
+ */
+void importGeoJson(
+    TileFeatureLayer& tile,
+    nlohmann::json const& geoJson,
+    GeoJsonImportOptions const& options = {});
+
+}

--- a/libs/model/include/mapget/model/geometry.h
+++ b/libs/model/include/mapget/model/geometry.h
@@ -106,6 +106,9 @@ public:
     /** Get the persisted logical stage of this geometry, if any. */
     [[nodiscard]] std::optional<uint32_t> stage() const;
 
+    /** Persist an explicit geometry stage override used by JSON import/export. */
+    void setStage(std::optional<uint32_t> geometryStage);
+
     /** Iterate over all Points in the geometry.
      * @param callback Function which is called for each contained point.
      *  Must return true to continue iteration, false to abort iteration.

--- a/libs/model/include/mapget/model/json-compare.h
+++ b/libs/model/include/mapget/model/json-compare.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+namespace mapget
+{
+
+/** Compare two floating-point values using mixed absolute/relative tolerance. */
+bool nearlyEqual(double a, double b, double epsilon);
+
+/**
+ * Compare arbitrary JSON values while tolerating small floating-point drift.
+ *
+ * When `errors` is provided, mismatches are appended as human-readable paths.
+ */
+bool compareJsonWithTolerance(
+    nlohmann::json const& expected,
+    nlohmann::json const& actual,
+    double floatTolerance = 1e-5,
+    std::vector<std::string>* errors = nullptr);
+
+/**
+ * Compare only the top-level `features` arrays of two feature collections.
+ *
+ * This is useful for snapshot tests where envelope metadata is intentionally
+ * ignored but per-feature structure must stay stable.
+ */
+bool compareFeatureCollectionJsonWithTolerance(
+    nlohmann::json const& expected,
+    nlohmann::json const& actual,
+    double floatTolerance = 1e-5,
+    std::vector<std::string>* errors = nullptr);
+
+/** Join collected comparison errors into a newline-separated debug string. */
+[[nodiscard]] std::string formatJsonComparisonErrors(std::vector<std::string> const& errors);
+
+}

--- a/libs/model/src/feature.cpp
+++ b/libs/model/src/feature.cpp
@@ -463,9 +463,16 @@ void Feature::updateFields() const {
         }
     }
 
-    // Add feature-specific id-part fields
-    for (auto const& [idPartName, value] : idNode->fields()) {
-        fields_.emplace_back(idPartName, value);
+    // Keep regular feature ids scalar in the node protocol. Feature export still
+    // needs the explicit id-part fields, so materialize them from the typed
+    // feature-id storage instead of relying on object-style child traversal.
+    if (idNode->values_) {
+        auto const limit = std::min(idNode->partNames_.size(), idNode->visibleValueIndices_.size());
+        for (size_t i = 0; i < limit; ++i) {
+            if (auto value = idNode->values_->at(static_cast<int64_t>(idNode->visibleValueIndices_[i]))) {
+                fields_.emplace_back(idNode->partNames_[i], value);
+            }
+        }
     }
 
     // Add other fields

--- a/libs/model/src/featureid.cpp
+++ b/libs/model/src/featureid.cpp
@@ -2,7 +2,11 @@
 #include "featurelayer.h"
 
 #include <algorithm>
+#include <charconv>
+#include <cctype>
 #include <string>
+#include <string_view>
+#include <vector>
 
 #include <fmt/format.h>
 
@@ -13,6 +17,7 @@ namespace mapget
 
 namespace
 {
+/** Resolve the concrete id composition used by a stored feature-id node. */
 std::vector<IdPart> const* resolveComposition(
     TileFeatureLayer const& model,
     simfil::StringId typeId,
@@ -34,6 +39,7 @@ std::vector<IdPart> const* resolveComposition(
     return &typeInfo->uniqueIdCompositions_[compositionIndex];
 }
 
+/** Build the externally visible id-part layout after removing an optional tile prefix. */
 void resolveVisiblePartLayout(
     TileFeatureLayer const& model,
     FeatureId::Data const& data,
@@ -91,6 +97,8 @@ void resolveVisiblePartLayout(
                 prefixFeatureIdParts,
                 prefixFeatureIdParts.size());
             if (!matchEndIndex) {
+                // A stored prefix that no longer matches the schema would make the
+                // visible id parts misleading, so we expose no parts instead.
                 return;
             }
             localStartIndex = *matchEndIndex;
@@ -120,6 +128,7 @@ void resolveVisiblePartLayout(
 }
 
 template<typename Fn>
+/** Forward a typed id-part value while rejecting node types that cannot appear in ids. */
 void appendTypedKeyValue(
     TileFeatureLayer const& model,
     simfil::StringId key,
@@ -145,6 +154,157 @@ void appendTypedKeyValue(
         valueNode->value());
 }
 
+/** Check whether a character can participate in a percent escape. */
+[[nodiscard]] bool isHexDigit(char ch)
+{
+    return std::isdigit(static_cast<unsigned char>(ch)) ||
+           (ch >= 'a' && ch <= 'f') ||
+           (ch >= 'A' && ch <= 'F');
+}
+
+/** Decode one hexadecimal digit used by feature-id escaping. */
+[[nodiscard]] uint8_t hexValue(char ch)
+{
+    if (ch >= '0' && ch <= '9') {
+        return static_cast<uint8_t>(ch - '0');
+    }
+    if (ch >= 'a' && ch <= 'f') {
+        return static_cast<uint8_t>(10 + (ch - 'a'));
+    }
+    return static_cast<uint8_t>(10 + (ch - 'A'));
+}
+
+/** Escape separators and escape markers inside string-valued id parts. */
+[[nodiscard]] std::string escapeFeatureIdPart(std::string_view input)
+{
+    std::string result;
+    result.reserve(input.size());
+    for (char ch : input) {
+        if (ch == '.') {
+            // Dots delimit id parts in the canonical string form.
+            result.append("%2E");
+        }
+        else if (ch == '%') {
+            // Existing escape markers must be preserved literally.
+            result.append("%25");
+        }
+        else {
+            result.push_back(ch);
+        }
+    }
+    return result;
+}
+
+/** Reverse percent escaping for a single canonical feature-id token. */
+[[nodiscard]] bool unescapeFeatureIdPart(
+    std::string_view input,
+    std::string& output,
+    std::string* error)
+{
+    output.clear();
+    output.reserve(input.size());
+    for (size_t i = 0; i < input.size(); ++i) {
+        char const ch = input[i];
+        if (ch != '%') {
+            output.push_back(ch);
+            continue;
+        }
+        if (i + 2 >= input.size() || !isHexDigit(input[i + 1]) || !isHexDigit(input[i + 2])) {
+            if (error) {
+                *error = fmt::format("Malformed percent escape in feature id token '{}'.", input);
+            }
+            return false;
+        }
+        auto const decoded = static_cast<char>((hexValue(input[i + 1]) << 4U) | hexValue(input[i + 2]));
+        output.push_back(decoded);
+        i += 2;
+    }
+    return true;
+}
+
+/** Split a canonical feature-id string into type and id-part tokens. */
+[[nodiscard]] std::vector<std::string_view> splitFeatureIdTokens(std::string_view input)
+{
+    std::vector<std::string_view> tokens;
+    size_t start = 0;
+    for (size_t i = 0; i <= input.size(); ++i) {
+        if (i == input.size() || input[i] == '.') {
+            tokens.push_back(input.substr(start, i - start));
+            start = i + 1;
+        }
+    }
+    return tokens;
+}
+
+struct CompositionParseState
+{
+    KeyValuePairs values;
+};
+
+/** Try to parse one id composition, including optional parts that may consume no token. */
+[[nodiscard]] bool tryParseCompositionRecursive(
+    std::vector<IdPart> const& composition,
+    std::vector<std::string_view> const& tokens,
+    size_t partIndex,
+    size_t tokenIndex,
+    CompositionParseState const& current,
+    std::vector<CompositionParseState>& results,
+    std::string* error)
+{
+    if (partIndex == composition.size()) {
+        if (tokenIndex == tokens.size()) {
+            results.push_back(current);
+            return true;
+        }
+        return false;
+    }
+
+    auto const& part = composition[partIndex];
+    auto matched = false;
+
+    if (part.isOptional_) {
+        // Optional parts are explored both as present and as omitted so we can
+        // disambiguate compositions solely from the canonical string form.
+        matched = tryParseCompositionRecursive(
+            composition,
+            tokens,
+            partIndex + 1,
+            tokenIndex,
+            current,
+            results,
+            error) || matched;
+    }
+
+    if (tokenIndex >= tokens.size()) {
+        return matched;
+    }
+
+    std::string decoded;
+    if (!unescapeFeatureIdPart(tokens[tokenIndex], decoded, error)) {
+        return false;
+    }
+
+    std::variant<int64_t, std::string> parsedValue = decoded;
+    std::string localError;
+    if (!part.validate(parsedValue, &localError)) {
+        // Datatype mismatches do not fail the whole search immediately because a
+        // different composition may still accept the same token sequence.
+        return matched;
+    }
+
+    auto next = current;
+    next.values.emplace_back(part.idPartLabel_, std::move(parsedValue));
+    return tryParseCompositionRecursive(
+               composition,
+               tokens,
+               partIndex + 1,
+               tokenIndex + 1,
+               next,
+               results,
+               error) || matched;
+}
+
+/** Append one node value to the canonical dot-separated feature-id string. */
 void appendNodeValueToString(std::string& out, simfil::ModelNode::Ptr const& node)
 {
     if (!node) {
@@ -162,6 +322,10 @@ void appendNodeValueToString(std::string& out, simfil::ModelNode::Ptr const& nod
                 if constexpr (std::is_same_v<T, bool>) {
                     fmt::format_to(std::back_inserter(out), FMT_STRING(".{:d}"), v);
                 }
+                else if constexpr (std::is_same_v<T, std::string_view> || std::is_same_v<T, std::string>) {
+                    // String-valued parts must escape canonical separators before joining.
+                    fmt::format_to(std::back_inserter(out), FMT_STRING(".{}"), escapeFeatureIdPart(v));
+                }
                 else {
                     fmt::format_to(std::back_inserter(out), FMT_STRING(".{}"), v);
                 }
@@ -169,7 +333,7 @@ void appendNodeValueToString(std::string& out, simfil::ModelNode::Ptr const& nod
         },
         node->value());
 }
-}
+}  // namespace
 
 FeatureId::FeatureId(FeatureId::Data& data,
     simfil::ModelConstPtr l,
@@ -319,6 +483,80 @@ KeyValueViewPairs FeatureId::keyValuePairs() const
     }
 
     return result;
+}
+
+bool parseFeatureIdString(
+    std::string_view featureId,
+    LayerInfo const& layerInfo,
+    ParsedFeatureId& result,
+    std::string* error)
+{
+    result = {};
+
+    auto const tokens = splitFeatureIdTokens(featureId);
+    if (tokens.empty() || tokens.front().empty()) {
+        if (error) {
+            *error = "Feature id must start with a non-empty type id.";
+        }
+        return false;
+    }
+
+    auto const typeId = std::string(tokens.front());
+    auto const* typeInfo = layerInfo.getTypeInfo(typeId, false);
+    if (!typeInfo) {
+        if (error) {
+            *error = fmt::format("Could not find feature type {}", typeId);
+        }
+        return false;
+    }
+
+    std::vector<std::pair<uint8_t, CompositionParseState>> matches;
+    std::string localError;
+    for (uint32_t compositionIndex = 0;
+         compositionIndex < typeInfo->uniqueIdCompositions_.size();
+         ++compositionIndex) {
+        auto const& composition = typeInfo->uniqueIdCompositions_[compositionIndex];
+        std::vector<CompositionParseState> parsedStates;
+        CompositionParseState emptyState{};
+        if (!tryParseCompositionRecursive(
+                composition,
+                std::vector<std::string_view>(tokens.begin() + 1, tokens.end()),
+                0,
+                0,
+                emptyState,
+                parsedStates,
+                &localError)) {
+            continue;
+        }
+        for (auto& parsed : parsedStates) {
+            // The parser keeps all valid matches so ambiguity can be reported explicitly.
+            matches.emplace_back(static_cast<uint8_t>(std::min<uint32_t>(compositionIndex, 255U)), std::move(parsed));
+        }
+    }
+
+    if (matches.empty()) {
+        if (error) {
+            *error = localError.empty()
+                ? fmt::format("Could not parse feature id '{}' for type '{}'.", featureId, typeId)
+                : localError;
+        }
+        return false;
+    }
+
+    if (matches.size() > 1) {
+        if (error) {
+            *error = fmt::format(
+                "Feature id '{}' matches multiple id compositions of type '{}'.",
+                featureId,
+                typeId);
+        }
+        return false;
+    }
+
+    result.typeId_ = typeId;
+    result.idCompositionIndex_ = matches.front().first;
+    result.keyValuePairs_ = std::move(matches.front().second.values);
+    return true;
 }
 
 }

--- a/libs/model/src/featureid.cpp
+++ b/libs/model/src/featureid.cpp
@@ -377,6 +377,28 @@ std::string_view FeatureId::typeId() const
     return "err-unresolved-typename";
 }
 
+std::string FeatureId::mapId() const
+{
+    if (auto mapId = externalMapId()) {
+        return std::string(*mapId);
+    }
+    return model().mapId();
+}
+
+std::optional<std::string_view> FeatureId::externalMapId() const
+{
+    if (data_.extMapId_ == simfil::StringPool::Empty) {
+        return std::nullopt;
+    }
+
+    if (auto resolved = model().strings()->resolve(data_.extMapId_)) {
+        return *resolved;
+    }
+
+    raise("FeatureId external map id is not known to string pool.");
+    return std::nullopt;
+}
+
 std::string FeatureId::toString() const
 {
     std::string result(typeId());
@@ -399,6 +421,37 @@ std::string FeatureId::toString() const
     }
 
     return result;
+}
+
+nlohmann::json FeatureId::toJson() const
+{
+    auto const canonicalId = toString();
+    if (auto mapId = externalMapId()) {
+        // External references need an explicit map payload because the canonical
+        // feature-id string deliberately stays scoped to one layer schema.
+        return nlohmann::json{
+            {"id", canonicalId},
+            {"mapId", *mapId},
+        };
+    }
+    return canonicalId;
+}
+
+ModelNode::Ptr FeatureId::jsonReferenceNode() const
+{
+    if (auto mapId = externalMapId()) {
+        auto exportModel = std::make_shared<simfil::ModelPool>();
+        auto objectNode = exportModel->newObject(2, true);
+        if (auto result = objectNode->addField("id", toString()); !result) {
+            raise(result.error().message);
+        }
+        if (auto result = objectNode->addField("mapId", std::string(*mapId)); !result) {
+            raise(result.error().message);
+        }
+        return objectNode;
+    }
+
+    return model_ptr<simfil::ValueNode>::make(toString(), model_);
 }
 
 simfil::ValueType FeatureId::type() const

--- a/libs/model/src/featureid.cpp
+++ b/libs/model/src/featureid.cpp
@@ -333,6 +333,23 @@ void appendNodeValueToString(std::string& out, simfil::ModelNode::Ptr const& nod
         },
         node->value());
 }
+
+/** Materialize one exported reference field for external-map feature ids. */
+[[nodiscard]] simfil::ModelNode::Ptr referenceFieldNode(
+    FeatureId const& featureId,
+    simfil::StringId field)
+{
+    auto owner = featureId.model().shared_from_this();
+    if (field == StringPool::IdStr) {
+        return model_ptr<simfil::ValueNode>::make(featureId.toString(), owner);
+    }
+    if (field == StringPool::MapIdStr) {
+        if (auto mapId = featureId.externalMapId()) {
+            return model_ptr<simfil::ValueNode>::make(std::string(*mapId), owner);
+        }
+    }
+    return {};
+}
 }  // namespace
 
 FeatureId::FeatureId(FeatureId::Data& data,
@@ -423,81 +440,62 @@ std::string FeatureId::toString() const
     return result;
 }
 
-nlohmann::json FeatureId::toJson() const
-{
-    auto const canonicalId = toString();
-    if (auto mapId = externalMapId()) {
-        // External references need an explicit map payload because the canonical
-        // feature-id string deliberately stays scoped to one layer schema.
-        return nlohmann::json{
-            {"id", canonicalId},
-            {"mapId", *mapId},
-        };
-    }
-    return canonicalId;
-}
-
-ModelNode::Ptr FeatureId::jsonReferenceNode() const
-{
-    if (auto mapId = externalMapId()) {
-        auto exportModel = std::make_shared<simfil::ModelPool>();
-        auto objectNode = exportModel->newObject(2, true);
-        if (auto result = objectNode->addField("id", toString()); !result) {
-            raise(result.error().message);
-        }
-        if (auto result = objectNode->addField("mapId", std::string(*mapId)); !result) {
-            raise(result.error().message);
-        }
-        return objectNode;
-    }
-
-    return model_ptr<simfil::ValueNode>::make(toString(), model_);
-}
-
 simfil::ValueType FeatureId::type() const
 {
-    return simfil::ValueType::String;
+    // Only external references need structural object access; all other ids
+    // stay canonical strings to preserve the historical feature-id surface.
+    return externalMapId().has_value() ? simfil::ValueType::Object : simfil::ValueType::String;
 }
 
 simfil::ScalarValueType FeatureId::value() const
 {
+    if (externalMapId()) {
+        return {};
+    }
     return toString();
 }
 
 simfil::ModelNode::Ptr FeatureId::at(int64_t i) const
 {
-    if (i < 0 || !values_ || i >= static_cast<int64_t>(visibleValueIndices_.size())) {
+    if (!externalMapId()) {
         return {};
     }
-    return values_->at(static_cast<int64_t>(visibleValueIndices_[static_cast<size_t>(i)]));
+    switch (i) {
+    case 0:
+        return referenceFieldNode(*this, StringPool::IdStr);
+    case 1:
+        return referenceFieldNode(*this, StringPool::MapIdStr);
+    default:
+        return {};
+    }
 }
 
 uint32_t FeatureId::size() const
 {
-    return static_cast<uint32_t>(visibleValueIndices_.size());
+    return externalMapId() ? 2U : 0U;
 }
 
 simfil::ModelNode::Ptr FeatureId::get(const simfil::StringId& f) const
 {
-    if (!values_) {
+    if (!externalMapId()) {
         return {};
     }
-
-    for (size_t i = 0; i < partNames_.size(); ++i) {
-        if (partNames_[i] == f && i < visibleValueIndices_.size()) {
-            return values_->at(static_cast<int64_t>(visibleValueIndices_[i]));
-        }
-    }
-
-    return {};
+    return referenceFieldNode(*this, f);
 }
 
 simfil::StringId FeatureId::keyAt(int64_t i) const
 {
-    if (i < 0 || i >= static_cast<int64_t>(partNames_.size())) {
+    if (!externalMapId()) {
         return {};
     }
-    return partNames_[static_cast<size_t>(i)];
+    switch (i) {
+    case 0:
+        return StringPool::IdStr;
+    case 1:
+        return StringPool::MapIdStr;
+    default:
+        return {};
+    }
 }
 
 bool FeatureId::iterate(const simfil::ModelNode::IterCallback& cb) const

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -694,6 +694,8 @@ simfil::model_ptr<Feature> TileFeatureLayer::newFeature(
                 value->value());
         }
     }
+    // Validation runs against the full logical feature id, even though only the
+    // non-prefix suffix is materialized into the compact feature storage.
     fullFeatureIdParts.insert(fullFeatureIdParts.end(), featureIdParts.begin(), featureIdParts.end());
 
     if (!layerInfo_->validFeatureId(typeId, fullFeatureIdParts, true)) {
@@ -703,6 +705,8 @@ simfil::model_ptr<Feature> TileFeatureLayer::newFeature(
             idPartsToString(fullFeatureIdParts)));
     }
     auto const& primaryIdComposition = getPrimaryIdComposition(typeId);
+    // Stored feature ids omit the common tile prefix to save space, so we first
+    // determine where the feature-local suffix starts within the composition.
     auto const localStartIndex = prefixFeatureIdParts.empty()
         ? 0U
         : *IdPart::compositionMatchEndIndex(
@@ -755,6 +759,8 @@ simfil::model_ptr<Feature> TileFeatureLayer::newFeature(
         auto const& expectedFeatureId = expectedFeatureIds_[featureIndex];
         auto const actualFeatureId = result.id()->toString();
         if (actualFeatureId != expectedFeatureId) {
+            // Overlay validation is sequence-based on purpose so stage imports
+            // fail immediately when converters reorder or drop features.
             raiseFmt(
                 "Feature sequence mismatch at index {}: expected {}, got {}.",
                 featureIndex,
@@ -1626,13 +1632,6 @@ nlohmann::json TileFeatureLayer::toJson() const
 
     if (impl_->glbAttachment_) {
         result["glbAttachment"] = impl_->glbAttachment_->toJsonMetadata();
-    }
-
-    // Add ID prefix if set
-    if (impl_->featureIdPrefix_) {
-        auto prefix = const_cast<TileFeatureLayer*>(this)->getIdPrefix();
-        if (prefix)
-            result["idPrefix"] = prefix->toJson();
     }
 
     // Add timestamp as ISO 8601 string
@@ -2625,58 +2624,11 @@ void TileFeatureLayer::setGeometrySourceDataReferences(
 
 model_ptr<Feature> TileFeatureLayer::find(const std::string_view& featureId) const
 {
-    using namespace std::ranges;
-    auto tokensRange = featureId | views::split('.');
-    auto tokens = std::vector<decltype(*tokensRange.begin())>(tokensRange.begin(), tokensRange.end());
-
-    if (tokens.empty()) {
+    ParsedFeatureId parsed;
+    if (!parseFeatureIdString(featureId, *layerInfo_, parsed)) {
         return {};
     }
-    auto tokenAt = [&tokens](auto&& i) {
-        return std::string_view(&*tokens[i].begin(), distance(tokens[i]));
-    };
-
-    auto typeInfo = layerInfo_->getTypeInfo(tokenAt(0), false);
-    if (!typeInfo || typeInfo->uniqueIdCompositions_.empty())
-        return {};
-
-    // Convert the part strings to key-value pairs using the first (primary) ID composition.
-    KeyValuePairs kvPairs;
-    for (auto withOptionalParts : {true, false}) {
-        size_t tokenIndex = 1;
-        bool error = false;
-        kvPairs.clear();
-
-        for (const auto& part : typeInfo->uniqueIdCompositions_[0]) {
-            if (part.isOptional_ && !withOptionalParts)
-                continue;
-
-            if (tokenIndex >= tokens.size()) {
-                error = true;
-                break;
-            }
-
-            std::variant<int64_t, std::string> parsedValue = std::string(tokenAt(tokenIndex++));
-            if (!part.validate(parsedValue)) {
-                error = true;
-                break;
-            }
-
-            kvPairs.emplace_back(part.idPartLabel_, parsedValue);
-        }
-
-        if (tokenIndex < tokens.size()) {
-            error = true;
-        }
-
-        if (error) {
-            if (!withOptionalParts)
-                return {};
-            // Go on to try without optional parts.
-        }
-    }
-
-    return find(typeInfo->name_, kvPairs);
+    return find(parsed.typeId_, parsed.keyValuePairs_);
 }
 
 }

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -786,7 +786,8 @@ simfil::model_ptr<Feature> TileFeatureLayer::newFeature(
 model_ptr<FeatureId>
 TileFeatureLayer::newFeatureId(
     const std::string_view& typeId,
-    const KeyValueViewPairs& featureIdParts)
+    const KeyValueViewPairs& featureIdParts,
+    std::optional<std::string_view> externalMapId)
 {
     if (!layerInfo_->validFeatureId(typeId, featureIdParts, false)) {
         raise(fmt::format(
@@ -803,11 +804,21 @@ TileFeatureLayer::newFeatureId(
         *layerInfo_->matchingFeatureIdCompositionIndex(typeId, featureIdParts, false);
     auto const& composition =
         layerInfo_->getTypeInfo(typeId)->uniqueIdCompositions_[idCompositionIndex];
+    simfil::StringId externalMapIdStringId = simfil::StringPool::Empty;
+    if (externalMapId && *externalMapId != mapId()) {
+        auto storedMapId = strings()->emplace(*externalMapId);
+        if (!storedMapId) {
+            raise(storedMapId.error().message);
+        }
+        // Local references omit the redundant map payload so legacy JSON stays compact.
+        externalMapIdStringId = *storedMapId;
+    }
     impl_->featureIds_.emplace_back(FeatureId::Data{
         false,
         idCompositionIndex,
         *typeIdStringId,
-        idPartValuesToArrayIndex(*this, composition, featureIdParts)
+        idPartValuesToArrayIndex(*this, composition, featureIdParts),
+        externalMapIdStringId,
     });
     return FeatureId(
         impl_->featureIds_.back(),
@@ -1171,7 +1182,8 @@ model_ptr<FeatureId> resolveInternal(tag<FeatureId>, TileFeatureLayer const& mod
                 true,
                 0,
                 featureData.typeIdAndLod_.typeId_,
-                featureData.idPartValues_},
+                featureData.idPartValues_,
+                simfil::StringPool::Empty},
             model.shared_from_this(),
             node.addr(),
             model.mpKey_);
@@ -2139,6 +2151,14 @@ TileFeatureLayer::setStrings(std::shared_ptr<simfil::StringPool> const& newDict)
             else
                 return tl::unexpected<simfil::Error>(res.error());
         }
+        if (fid.extMapId_ != simfil::StringPool::Empty) {
+            if (auto resolvedName = oldDict->resolve(fid.extMapId_)) {
+                if (auto res = newDict->emplace(*resolvedName))
+                    fid.extMapId_ = *res;
+                else
+                    return tl::unexpected<simfil::Error>(res.error());
+            }
+        }
     }
     for (auto& feature : impl_->features_) {
         if (auto resolvedName = oldDict->resolve(feature.typeIdAndLod_.typeId_)) {
@@ -2292,13 +2312,19 @@ ModelNode::Ptr TileFeatureLayer::clone(
     }
     case ColumnId::FeatureIds: {
         auto resolved = otherLayer->resolve<FeatureId>(*otherNode);
-        auto newNode = newFeatureId(resolved->typeId(), resolved->keyValuePairs());
+        auto newNode = newFeatureId(
+            resolved->typeId(),
+            resolved->keyValuePairs(),
+            resolved->externalMapId());
         newCacheNode = newNode;
         break;
     }
     case ColumnId::ExternalFeatureIds: {
         auto resolved = otherLayer->resolve<FeatureId>(*otherNode);
-        auto newNode = newFeatureId(resolved->typeId(), resolved->keyValuePairs());
+        auto newNode = newFeatureId(
+            resolved->typeId(),
+            resolved->keyValuePairs(),
+            resolved->externalMapId());
         newCacheNode = newNode;
         break;
     }

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -1646,21 +1646,9 @@ nlohmann::json TileFeatureLayer::toJson() const
         result["glbAttachment"] = impl_->glbAttachment_->toJsonMetadata();
     }
 
-    // Add timestamp as ISO 8601 string
-    {
-        auto time_t_val = std::chrono::system_clock::to_time_t(timestamp_);
-        auto microseconds = std::chrono::duration_cast<std::chrono::microseconds>(
-            timestamp_.time_since_epoch()).count() % 1000000;
-        std::tm tm_val{};
-#ifdef _WIN32
-        gmtime_s(&tm_val, &time_t_val);
-#else
-        gmtime_r(&time_t_val, &tm_val);
-#endif
-        char buf[32];
-        std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%S", &tm_val);
-        result["timestamp"] = fmt::format("{}.{:06d}Z", buf, microseconds);
-    }
+    // Preserve the binary timestamp representation exactly in strict JSON.
+    result["timestamp"] = std::chrono::duration_cast<std::chrono::microseconds>(
+        timestamp_.time_since_epoch()).count();
 
     // Add TTL if set (in milliseconds)
     if (ttl_)

--- a/libs/model/src/geojson-import.cpp
+++ b/libs/model/src/geojson-import.cpp
@@ -14,8 +14,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <cstdio>
-#include <ctime>
 #include <limits>
 #include <optional>
 #include <string>
@@ -35,66 +33,6 @@ namespace
 [[noreturn]] void raiseImport(std::string const& message)
 {
     raiseFmt("TileFeatureLayer::fromJson: {}", message);
-}
-
-/** Parse the timestamp format emitted by TileFeatureLayer::toJson(). */
-[[nodiscard]] auto parseTimestamp(std::string const& input)
-    -> std::optional<std::chrono::time_point<std::chrono::system_clock>>
-{
-    if (input.size() < 20 || input.back() != 'Z') {
-        return std::nullopt;
-    }
-
-    int year = 0;
-    int month = 0;
-    int day = 0;
-    int hour = 0;
-    int minute = 0;
-    int second = 0;
-    if (std::sscanf(
-            input.c_str(),
-            "%4d-%2d-%2dT%2d:%2d:%2d",
-            &year,
-            &month,
-            &day,
-            &hour,
-            &minute,
-            &second) != 6) {
-        return std::nullopt;
-    }
-
-    int micros = 0;
-    auto const dotPos = input.find('.');
-    if (dotPos != std::string::npos) {
-        auto const frac = input.substr(dotPos + 1, input.size() - dotPos - 2);
-        if (frac.size() > 6) {
-            return std::nullopt;
-        }
-        // Export always uses microsecond precision, so shorter fractions are right-padded.
-        std::string padded = frac;
-        padded.append(6 - padded.size(), '0');
-        for (char ch : padded) {
-            if (ch < '0' || ch > '9') {
-                return std::nullopt;
-            }
-        }
-        micros = std::stoi(padded);
-    }
-
-    std::tm tmValue{};
-    tmValue.tm_year = year - 1900;
-    tmValue.tm_mon = month - 1;
-    tmValue.tm_mday = day;
-    tmValue.tm_hour = hour;
-    tmValue.tm_min = minute;
-    tmValue.tm_sec = second;
-
-    auto const epoch = timegm(&tmValue);
-    if (epoch < 0) {
-        return std::nullopt;
-    }
-
-    return std::chrono::system_clock::from_time_t(epoch) + std::chrono::microseconds(micros);
 }
 
 /** Parse mapget validity direction labels, including legacy aliases. */
@@ -1038,11 +976,12 @@ void importGeoJson(
         tile.setGeometryAnchor(pointFromCoordinateJson(geoJson.at("geometryAnchor")));
     }
     if (geoJson.contains("timestamp")) {
-        auto parsed = parseTimestamp(geoJson.at("timestamp").get<std::string>());
-        if (!parsed) {
-            raiseImport("Invalid timestamp format.");
+        auto const& timestampJson = geoJson.at("timestamp");
+        if (!timestampJson.is_number_integer()) {
+            raiseImport("timestamp must be encoded as integer microseconds since the Unix epoch.");
         }
-        tile.setTimestamp(*parsed);
+        tile.setTimestamp(std::chrono::time_point<std::chrono::system_clock>(
+            std::chrono::microseconds(timestampJson.get<int64_t>())));
     }
     if (geoJson.contains("ttl")) {
         tile.setTtl(std::chrono::milliseconds(geoJson.at("ttl").get<int64_t>()));

--- a/libs/model/src/geojson-import.cpp
+++ b/libs/model/src/geojson-import.cpp
@@ -1,0 +1,1110 @@
+#include "mapget/model/geojson-import.h"
+
+#include "mapget/model/attr.h"
+#include "mapget/model/attrlayer.h"
+#include "mapget/model/feature.h"
+#include "mapget/model/featureid.h"
+#include "mapget/model/featurelayer.h"
+#include "mapget/model/geometry.h"
+#include "mapget/model/relation.h"
+#include "mapget/model/sourcedatareference.h"
+#include "mapget/model/validity.h"
+#include "mapget/log.h"
+#include "simfil/model/json.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+namespace mapget
+{
+
+namespace
+{
+/** Raise a consistently prefixed import error. */
+[[noreturn]] void raiseImport(std::string const& message)
+{
+    raiseFmt("TileFeatureLayer::fromJson: {}", message);
+}
+
+/** Parse the timestamp format emitted by TileFeatureLayer::toJson(). */
+[[nodiscard]] auto parseTimestamp(std::string const& input)
+    -> std::optional<std::chrono::time_point<std::chrono::system_clock>>
+{
+    if (input.size() < 20 || input.back() != 'Z') {
+        return std::nullopt;
+    }
+
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    int second = 0;
+    if (std::sscanf(
+            input.c_str(),
+            "%4d-%2d-%2dT%2d:%2d:%2d",
+            &year,
+            &month,
+            &day,
+            &hour,
+            &minute,
+            &second) != 6) {
+        return std::nullopt;
+    }
+
+    int micros = 0;
+    auto const dotPos = input.find('.');
+    if (dotPos != std::string::npos) {
+        auto const frac = input.substr(dotPos + 1, input.size() - dotPos - 2);
+        if (frac.size() > 6) {
+            return std::nullopt;
+        }
+        // Export always uses microsecond precision, so shorter fractions are right-padded.
+        std::string padded = frac;
+        padded.append(6 - padded.size(), '0');
+        for (char ch : padded) {
+            if (ch < '0' || ch > '9') {
+                return std::nullopt;
+            }
+        }
+        micros = std::stoi(padded);
+    }
+
+    std::tm tmValue{};
+    tmValue.tm_year = year - 1900;
+    tmValue.tm_mon = month - 1;
+    tmValue.tm_mday = day;
+    tmValue.tm_hour = hour;
+    tmValue.tm_min = minute;
+    tmValue.tm_sec = second;
+
+    auto const epoch = timegm(&tmValue);
+    if (epoch < 0) {
+        return std::nullopt;
+    }
+
+    return std::chrono::system_clock::from_time_t(epoch) + std::chrono::microseconds(micros);
+}
+
+/** Parse mapget validity direction labels, including legacy aliases. */
+[[nodiscard]] std::optional<Validity::Direction> directionFromJson(nlohmann::json const& json)
+{
+    if (!json.is_string()) {
+        return std::nullopt;
+    }
+
+    auto const value = json.get<std::string>();
+    if (value == "POSITIVE") {
+        return Validity::Positive;
+    }
+    if (value == "NEGATIVE") {
+        return Validity::Negative;
+    }
+    if (value == "COMPLETE" || value == "BOTH") {
+        return Validity::Both;
+    }
+    if (value == "NONE") {
+        return Validity::None;
+    }
+    if (value == "EMPTY") {
+        return Validity::Empty;
+    }
+    return std::nullopt;
+}
+
+/** Parse transition endpoint labels used by feature-transition validities. */
+[[nodiscard]] std::optional<Validity::TransitionEnd> transitionEndFromJson(nlohmann::json const& json)
+{
+    if (!json.is_string()) {
+        return std::nullopt;
+    }
+    auto const value = json.get<std::string>();
+    if (value == "START") {
+        return Validity::Start;
+    }
+    if (value == "END") {
+        return Validity::End;
+    }
+    return std::nullopt;
+}
+
+/** Parse the offset encoding used by position/range validities. */
+[[nodiscard]] std::optional<Validity::GeometryOffsetType> offsetTypeFromJson(nlohmann::json const& json)
+{
+    if (!json.is_string()) {
+        return std::nullopt;
+    }
+    auto const value = json.get<std::string>();
+    if (value == "GeoPosOffset") {
+        return Validity::GeoPosOffset;
+    }
+    if (value == "BufferOffset") {
+        return Validity::BufferOffset;
+    }
+    if (value == "RelativeLengthOffset") {
+        return Validity::RelativeLengthOffset;
+    }
+    if (value == "MetricLengthOffset") {
+        return Validity::MetricLengthOffset;
+    }
+    return std::nullopt;
+}
+
+/** Parse a GeoJSON position into mapget's Point type. */
+[[nodiscard]] Point pointFromCoordinateJson(nlohmann::json const& json)
+{
+    if (!json.is_array() || json.size() < 2 || json.size() > 3) {
+        raiseImport("Expected GeoJSON coordinate array with 2 or 3 numeric elements.");
+    }
+    return Point{
+        json.at(0).get<double>(),
+        json.at(1).get<double>(),
+        json.size() >= 3 ? json.at(2).get<double>() : 0.0};
+}
+
+/** Decode a JSON scalar into the storage type expected by an id-part definition. */
+[[nodiscard]] std::variant<int64_t, std::string> jsonToIdPartValue(
+    nlohmann::json const& json,
+    IdPart const& idPart)
+{
+    if (json.is_number_integer()) {
+        return json.get<int64_t>();
+    }
+    if (json.is_number_unsigned()) {
+        auto const value = json.get<uint64_t>();
+        if (value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+            raiseImport(fmt::format("Id part '{}' exceeds int64_t range.", idPart.idPartLabel_));
+        }
+        return static_cast<int64_t>(value);
+    }
+    if (json.is_string()) {
+        return json.get<std::string>();
+    }
+    raiseImport(fmt::format(
+        "Id part '{}' must be encoded as an integer or string JSON value.",
+        idPart.idPartLabel_));
+}
+
+/** Validate an id-part value with the same rules used by binary feature creation. */
+void validateIdPartValue(
+    IdPart const& idPart,
+    std::variant<int64_t, std::string>& value)
+{
+    std::string error;
+    if (!idPart.validate(value, &error)) {
+        raiseImport(error);
+    }
+}
+
+/** Delegate generic object/array/scalar import to simfil's shared JSON builder. */
+[[nodiscard]] simfil::ModelNode::Ptr importGenericNode(
+    TileFeatureLayer& tile,
+    nlohmann::json const& json)
+{
+    auto node = simfil::json::buildModelNode(json, tile);
+    if (!node) {
+        raiseImport(node.error().message);
+    }
+    return *node;
+}
+
+/** Find either `_sourceData` or the legacy `sourceData` alias on a JSON object. */
+[[nodiscard]] nlohmann::json const* findSourceDataJson(nlohmann::json const& json)
+{
+    if (!json.is_object()) {
+        return nullptr;
+    }
+    if (auto it = json.find("_sourceData"); it != json.end()) {
+        return &(*it);
+    }
+    if (auto it = json.find("sourceData"); it != json.end()) {
+        return &(*it);
+    }
+    return nullptr;
+}
+
+/** Resolve a geometry stage label back to its layer-specific numeric stage. */
+[[nodiscard]] std::optional<uint32_t> stageFromGeometryName(
+    TileFeatureLayer const& tile,
+    nlohmann::json const& json,
+    bool strict)
+{
+    auto const* layerInfo = tile.layerInfo().get();
+    if (!layerInfo) {
+        return std::nullopt;
+    }
+    if (!json.contains("geometryName")) {
+        return layerInfo->highFidelityStage_;
+    }
+    if (!json.at("geometryName").is_string()) {
+        raiseImport("geometryName must be a string.");
+    }
+    auto const label = json.at("geometryName").get<std::string>();
+    auto const& labels = layerInfo->stageLabels_;
+    std::optional<uint32_t> matchedStage;
+    for (uint32_t i = 0; i < labels.size(); ++i) {
+        if (labels[i] != label) {
+            continue;
+        }
+        if (matchedStage) {
+            if (strict) {
+                raiseImport(fmt::format(
+                    "Ambiguous geometryName '{}' for layer '{}'.",
+                    label,
+                    layerInfo->layerId_));
+            }
+            // In best-effort mode ambiguous labels are ignored rather than guessed.
+            return std::nullopt;
+        }
+        matchedStage = i;
+    }
+    if (!matchedStage) {
+        if (strict) {
+            raiseImport(fmt::format(
+                "Unknown geometryName '{}' for layer '{}'.",
+                label,
+                layerInfo->layerId_));
+        }
+        return std::nullopt;
+    }
+    return matchedStage;
+}
+
+/** Restrict best-effort synthetic ids to integer id-part slots. */
+[[nodiscard]] bool isIntegerIdPart(IdPartDataType datatype)
+{
+    switch (datatype) {
+    case IdPartDataType::I32:
+    case IdPartDataType::U32:
+    case IdPartDataType::I64:
+    case IdPartDataType::U64:
+        return true;
+    case IdPartDataType::UUID128:
+    case IdPartDataType::STR:
+        return false;
+    }
+    return false;
+}
+
+/**
+ * Synthesize full feature-id parts for permissive GeoJSON import.
+ *
+ * The tile id is injected when the composition contains a `tileId` part, and
+ * the first remaining integer slot is filled with the feature's collection index.
+ */
+[[nodiscard]] KeyValuePairs bestEffortFullFeatureIdParts(
+    TileFeatureLayer const& tile,
+    std::string_view typeId,
+    uint32_t fallbackFeatureIndex)
+{
+    auto const* typeInfo = tile.layerInfo()->getTypeInfo(typeId, false);
+    if (!typeInfo || typeInfo->uniqueIdCompositions_.empty()) {
+        raiseImport(fmt::format(
+            "Could not resolve feature type '{}' for best-effort import.",
+            typeId));
+    }
+
+    if (tile.tileId().value_ > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+        raiseImport("tileId exceeds signed integer range needed for best-effort id synthesis.");
+    }
+
+    auto const& composition = typeInfo->uniqueIdCompositions_.front();
+    KeyValuePairs parts;
+    parts.reserve(composition.size());
+    bool usedFeatureIndex = false;
+
+    for (auto const& idPart : composition) {
+        if (idPart.idPartLabel_ == "tileId") {
+            if (!isIntegerIdPart(idPart.datatype_)) {
+                raiseImport("Best-effort GeoJSON import requires an integer tileId id part.");
+            }
+            parts.emplace_back(idPart.idPartLabel_, static_cast<int64_t>(tile.tileId().value_));
+            continue;
+        }
+
+        if (!usedFeatureIndex && isIntegerIdPart(idPart.datatype_)) {
+            // Best-effort mode needs one deterministic per-feature slot to keep ids stable.
+            parts.emplace_back(idPart.idPartLabel_, static_cast<int64_t>(fallbackFeatureIndex));
+            usedFeatureIndex = true;
+            continue;
+        }
+
+        if (idPart.isOptional_) {
+            // Optional suffix parts may be dropped because no source field exists to recover them.
+            continue;
+        }
+
+        raiseImport(fmt::format(
+            "Could not synthesize best-effort feature ids for type '{}'. "
+            "Provide explicit id fields for required part '{}'.",
+            typeId,
+            idPart.idPartLabel_));
+    }
+
+    if (!usedFeatureIndex) {
+        raiseImport(fmt::format(
+            "Could not synthesize best-effort feature ids for type '{}'. "
+            "The primary id composition has no usable per-feature integer part.",
+            typeId));
+    }
+
+    return parts;
+}
+
+/** Read all required id fields for strict import from the feature JSON object. */
+[[nodiscard]] KeyValuePairs fullFeatureIdPartsFromFields(
+    nlohmann::json const& featureJson,
+    std::vector<IdPart> const& composition)
+{
+    KeyValuePairs result;
+    result.reserve(composition.size());
+
+    for (auto const& idPart : composition) {
+        auto it = featureJson.find(idPart.idPartLabel_);
+        if (it == featureJson.end()) {
+            if (idPart.isOptional_) {
+                continue;
+            }
+            raiseImport(fmt::format(
+                "Feature is missing non-optional id field '{}' required by the primary composition.",
+                idPart.idPartLabel_));
+        }
+        auto value = jsonToIdPartValue(*it, idPart);
+        validateIdPartValue(idPart, value);
+        result.emplace_back(idPart.idPartLabel_, std::move(value));
+    }
+
+    return result;
+}
+
+/** Import source-data references from the JSON representation used by toJson(). */
+[[nodiscard]] std::optional<model_ptr<SourceDataReferenceCollection>> importSourceDataReferences(
+    TileFeatureLayer& tile,
+    nlohmann::json const& json)
+{
+    if (json.is_null()) {
+        return std::nullopt;
+    }
+    if (!json.is_array()) {
+        raiseImport("sourceData must be encoded as an array.");
+    }
+
+    std::vector<QualifiedSourceDataReference> refs;
+    refs.reserve(json.size());
+    for (auto const& item : json) {
+        if (!item.is_object()) {
+            raiseImport("Every sourceData entry must be an object.");
+        }
+        if (!item.contains("address") || !item.contains("layerId") || !item.contains("qualifier")) {
+            raiseImport("Every sourceData entry must contain address, layerId, and qualifier.");
+        }
+
+        uint64_t address = 0;
+        if (item.at("address").is_number_unsigned()) {
+            address = item.at("address").get<uint64_t>();
+        }
+        else if (item.at("address").is_number_integer()) {
+            auto const signedAddress = item.at("address").get<int64_t>();
+            if (signedAddress < 0) {
+                raiseImport("sourceData address must not be negative.");
+            }
+            address = static_cast<uint64_t>(signedAddress);
+        }
+        else {
+            raiseImport("sourceData address must be an integer.");
+        }
+
+        auto layerId = item.at("layerId").get<std::string>();
+        auto qualifier = item.at("qualifier").get<std::string>();
+        auto layerIdId = tile.strings()->emplace(layerId);
+        if (!layerIdId) {
+            raiseImport(layerIdId.error().message);
+        }
+        auto qualifierId = tile.strings()->emplace(qualifier);
+        if (!qualifierId) {
+            raiseImport(qualifierId.error().message);
+        }
+
+        refs.push_back(QualifiedSourceDataReference{
+            SourceDataAddress{address},
+            *layerIdId,
+            *qualifierId,
+        });
+    }
+
+    return tile.newSourceDataReferenceCollection(refs);
+}
+
+/** Parse a canonical feature-id string into a detached FeatureId node. */
+[[nodiscard]] model_ptr<FeatureId> importFeatureReferenceId(
+    TileFeatureLayer& tile,
+    nlohmann::json const& json)
+{
+    if (!json.is_string()) {
+        raiseImport("Feature references must be encoded as canonical feature-id strings.");
+    }
+
+    ParsedFeatureId parsed;
+    std::string error;
+    if (!parseFeatureIdString(json.get<std::string>(), *tile.layerInfo(), parsed, &error)) {
+        raiseImport(error);
+    }
+    auto partsView = castToKeyValueView(parsed.keyValuePairs_);
+    return tile.newFeatureId(parsed.typeId_, partsView);
+}
+
+/** Resolve a canonical feature-id string to a feature already created in this tile. */
+[[nodiscard]] model_ptr<Feature> resolveLocalFeatureReference(
+    TileFeatureLayer& tile,
+    nlohmann::json const& json)
+{
+    if (!json.is_string()) {
+        raiseImport("Feature transition references must be encoded as canonical feature-id strings.");
+    }
+
+    ParsedFeatureId parsed;
+    std::string error;
+    if (!parseFeatureIdString(json.get<std::string>(), *tile.layerInfo(), parsed, &error)) {
+        raiseImport(error);
+    }
+
+    if (auto feature = tile.find(parsed.typeId_, parsed.keyValuePairs_)) {
+        return feature;
+    }
+    raiseImport(fmt::format("Could not resolve local feature reference '{}'.", json.get<std::string>()));
+    return {};
+}
+
+[[nodiscard]] model_ptr<Geometry> importStandaloneGeometry(
+    TileFeatureLayer& tile,
+    nlohmann::json const& geometryJson,
+    GeoJsonImportOptions const& options);
+
+/** Apply metadata that is shared by all geometry encodings. */
+void applyGeometryDecorations(
+    TileFeatureLayer& tile,
+    model_ptr<Geometry> geometry,
+    nlohmann::json const& geometryJson,
+    GeoJsonImportOptions const& options)
+{
+    if (!geometry) {
+        return;
+    }
+
+    if (auto stage = stageFromGeometryName(tile, geometryJson, options.strict_)) {
+        geometry->setStage(*stage);
+    }
+    if (auto sourceDataJson = findSourceDataJson(geometryJson)) {
+        if (auto refs = importSourceDataReferences(tile, *sourceDataJson)) {
+            geometry->setSourceDataReferences(*refs);
+        }
+    }
+}
+
+/** Import one standalone geometry object outside of feature-collection splitting logic. */
+[[nodiscard]] model_ptr<Geometry> importStandaloneGeometry(
+    TileFeatureLayer& tile,
+    nlohmann::json const& geometryJson,
+    GeoJsonImportOptions const& options)
+{
+    if (!geometryJson.is_object()) {
+        raiseImport("Geometry must be a JSON object.");
+    }
+    if (!geometryJson.contains("type") || !geometryJson.at("type").is_string()) {
+        raiseImport("Geometry object is missing string field 'type'.");
+    }
+
+    auto const type = geometryJson.at("type").get<std::string>();
+
+    if (type == "Point") {
+        auto geometry = tile.newGeometry(GeomType::Points, 1, true);
+        geometry->append(pointFromCoordinateJson(geometryJson.at("coordinates")));
+        applyGeometryDecorations(tile, geometry, geometryJson, options);
+        return geometry;
+    }
+
+    if (type == "MultiPoint") {
+        auto const& coords = geometryJson.at("coordinates");
+        auto geometry = tile.newGeometry(GeomType::Points, coords.size(), true);
+        for (auto const& coord : coords) {
+            geometry->append(pointFromCoordinateJson(coord));
+        }
+        applyGeometryDecorations(tile, geometry, geometryJson, options);
+        return geometry;
+    }
+
+    if (type == "LineString") {
+        auto const& coords = geometryJson.at("coordinates");
+        auto geometry = tile.newGeometry(GeomType::Line, coords.size(), true);
+        for (auto const& coord : coords) {
+            geometry->append(pointFromCoordinateJson(coord));
+        }
+        applyGeometryDecorations(tile, geometry, geometryJson, options);
+        return geometry;
+    }
+
+    if (type == "MultiLineString") {
+        raiseImport("Standalone validity geometries do not support MultiLineString values.");
+    }
+
+    if (type == "Polygon") {
+        if (geometryJson.contains("gltfNodeIndex")) {
+            raiseImport("GLTF-backed geometry import is not supported yet.");
+        }
+        if (geometryJson.contains("aabb")) {
+            auto const& aabb = geometryJson.at("aabb");
+            auto geometry = tile.newGeometry(GeomType::AABB, 2, true);
+            geometry->setAabb(
+                pointFromCoordinateJson(aabb.at("origin")),
+                pointFromCoordinateJson(aabb.at("size")));
+            applyGeometryDecorations(tile, geometry, geometryJson, options);
+            return geometry;
+        }
+
+        auto const& coords = geometryJson.at("coordinates");
+        if (!coords.is_array() || coords.empty()) {
+            raiseImport("Polygon coordinates must contain at least one linear ring.");
+        }
+        if (coords.size() > 1 && options.strict_) {
+            // Native mapget polygons do not preserve hole rings, so strict mode rejects them.
+            raiseImport("Polygon holes are not supported by mapget polygon geometries.");
+        }
+        auto const& outerRing = coords.at(0);
+        auto geometry = tile.newGeometry(GeomType::Polygon, outerRing.size(), true);
+        for (auto const& coord : outerRing) {
+            geometry->append(pointFromCoordinateJson(coord));
+        }
+        applyGeometryDecorations(tile, geometry, geometryJson, options);
+        return geometry;
+    }
+
+    if (type == "MultiPolygon") {
+        auto const& polygons = geometryJson.at("coordinates");
+        if (!options.strict_) {
+            raiseImport("Standalone generic MultiPolygon import requires a feature context.");
+        }
+        auto geometry = tile.newGeometry(GeomType::Mesh, polygons.size() * 3, true);
+        for (auto const& polygon : polygons) {
+            if (!polygon.is_array() || polygon.size() != 1 || !polygon.at(0).is_array()) {
+                raiseImport("Strict mapget mesh import expects every MultiPolygon item to contain exactly one ring.");
+            }
+            auto const& ring = polygon.at(0);
+            std::vector<Point> triangle;
+            triangle.reserve(ring.size());
+            for (auto const& coord : ring) {
+                triangle.push_back(pointFromCoordinateJson(coord));
+            }
+            if (!triangle.empty() && triangle.front() == triangle.back()) {
+                // GeoJSON triangle rings are closed, while mapget mesh triangles are stored open.
+                triangle.pop_back();
+            }
+            if (triangle.size() != 3) {
+                raiseImport("Strict mapget mesh import expects triangular MultiPolygon rings.");
+            }
+            for (auto const& point : triangle) {
+                geometry->append(point);
+            }
+        }
+        applyGeometryDecorations(tile, geometry, geometryJson, options);
+        return geometry;
+    }
+
+    if (type == "GeometryCollection") {
+        raiseImport("Standalone validity geometries do not support GeometryCollection values.");
+    }
+
+    raiseImport(fmt::format("Unsupported geometry type '{}'.", type));
+    return {};
+}
+
+/** Import feature geometry, expanding GeoJSON aggregate types into mapget's geometry list. */
+void importFeatureGeometry(
+    TileFeatureLayer& tile,
+    model_ptr<Feature> feature,
+    nlohmann::json const& geometryJson,
+    GeoJsonImportOptions const& options)
+{
+    if (geometryJson.is_null()) {
+        return;
+    }
+    if (!geometryJson.is_object()) {
+        raiseImport("Feature geometry must be an object or null.");
+    }
+
+    if (!geometryJson.contains("type") || !geometryJson.at("type").is_string()) {
+        raiseImport("Feature geometry must contain a string field 'type'.");
+    }
+    auto const type = geometryJson.at("type").get<std::string>();
+    if (type == "GeometryCollection") {
+        if (!geometryJson.contains("geometries") || !geometryJson.at("geometries").is_array()) {
+            raiseImport("GeometryCollection is missing array-valued field 'geometries'.");
+        }
+        for (auto const& child : geometryJson.at("geometries")) {
+            auto geometry = importStandaloneGeometry(tile, child, GeoJsonImportOptions{options.strict_, options.fallbackFeatureType_, options.objectPropertiesAsAttributeLayers_});
+            feature->addGeometry(geometry);
+        }
+        return;
+    }
+
+    if (type == "MultiLineString") {
+        auto const& lines = geometryJson.at("coordinates");
+        for (auto const& line : lines) {
+            // mapget represents multi-lines as multiple line geometries on one feature.
+            auto lineJson = nlohmann::json::object({
+                {"type", "LineString"},
+                {"coordinates", line},
+            });
+            if (geometryJson.contains("geometryName")) {
+                lineJson["geometryName"] = geometryJson.at("geometryName");
+            }
+            if (auto sourceDataJson = findSourceDataJson(geometryJson)) {
+                lineJson["_sourceData"] = *sourceDataJson;
+            }
+            auto geometry = importStandaloneGeometry(tile, lineJson, options);
+            feature->addGeometry(geometry);
+        }
+        return;
+    }
+
+    if (type == "MultiPolygon" && !options.strict_) {
+        auto const& polygons = geometryJson.at("coordinates");
+        for (auto const& polygon : polygons) {
+            if (!polygon.is_array() || polygon.empty() || !polygon.at(0).is_array()) {
+                raiseImport("Generic MultiPolygon import expects every polygon to contain at least one ring.");
+            }
+            // Best-effort mode degrades each polygon to its outer ring because mapget polygons have no holes.
+            auto polyJson = nlohmann::json::object({
+                {"type", "Polygon"},
+                {"coordinates", nlohmann::json::array({polygon.at(0)})},
+            });
+            if (auto stage = stageFromGeometryName(tile, geometryJson, options.strict_)) {
+                polyJson["geometryName"] = geometryJson.at("geometryName");
+            }
+            if (auto sourceDataJson = findSourceDataJson(geometryJson)) {
+                polyJson["_sourceData"] = *sourceDataJson;
+            }
+            auto geometry = importStandaloneGeometry(tile, polyJson, options);
+            feature->addGeometry(geometry);
+        }
+        return;
+    }
+
+    auto geometry = importStandaloneGeometry(tile, geometryJson, options);
+    feature->addGeometry(geometry);
+}
+
+/** Import one validity or validity list into mapget's MultiValidity container. */
+void importValidityCollection(
+    TileFeatureLayer& tile,
+    model_ptr<Feature> hostFeature,
+    model_ptr<MultiValidity> collection,
+    nlohmann::json const& json,
+    GeoJsonImportOptions const& options)
+{
+    auto values = json.is_array() ? json : nlohmann::json::array({json});
+    for (auto const& value : values) {
+        if (!value.is_object()) {
+            raiseImport("Validity entries must be JSON objects.");
+        }
+
+        auto validity = tile.newValidity();
+        if (value.contains("direction")) {
+            auto direction = directionFromJson(value.at("direction"));
+            if (!direction) {
+                raiseImport(fmt::format("Unknown validity direction '{}'.", value.at("direction").dump()));
+            }
+            validity->setDirection(*direction);
+        }
+        if (auto stage = stageFromGeometryName(tile, value, options.strict_)) {
+            validity->setGeometryStage(*stage);
+        }
+
+        if (value.contains("from") || value.contains("to")) {
+            // Transition validities are the only variant that references two local features.
+            if (!value.contains("from") || !value.contains("to") ||
+                !value.contains("fromConnectedEnd") || !value.contains("toConnectedEnd") ||
+                !value.contains("transitionNumber")) {
+                raiseImport("Feature transition validities must define from/to ids, connected ends, and transitionNumber.");
+            }
+            auto fromFeature = resolveLocalFeatureReference(tile, value.at("from"));
+            auto toFeature = resolveLocalFeatureReference(tile, value.at("to"));
+            auto fromEnd = transitionEndFromJson(value.at("fromConnectedEnd"));
+            auto toEnd = transitionEndFromJson(value.at("toConnectedEnd"));
+            if (!fromEnd || !toEnd) {
+                raiseImport("Invalid transition end in feature transition validity.");
+            }
+            validity->setFeatureTransition(
+                fromFeature,
+                *fromEnd,
+                toFeature,
+                *toEnd,
+                value.at("transitionNumber").get<uint32_t>());
+            collection->append(validity);
+            continue;
+        }
+
+        if (value.contains("geometry")) {
+            validity->setSimpleGeometry(importStandaloneGeometry(tile, value.at("geometry"), options));
+            collection->append(validity);
+            continue;
+        }
+
+        if (value.contains("featureId")) {
+            validity->setFeatureId(importFeatureReferenceId(tile, value.at("featureId")));
+        }
+
+        auto offsetType = value.contains("offsetType") ? offsetTypeFromJson(value.at("offsetType")) : std::optional<Validity::GeometryOffsetType>{};
+        if (value.contains("offsetType") && !offsetType) {
+            raiseImport(fmt::format("Unknown validity offsetType '{}'.", value.at("offsetType").dump()));
+        }
+
+        if (value.contains("point")) {
+            if (offsetType && *offsetType != Validity::GeoPosOffset) {
+                // Non-geospatial offsets reuse the `point` field name for historic JSON compatibility.
+                validity->setOffsetPoint(*offsetType, value.at("point").get<double>());
+            }
+            else {
+                validity->setOffsetPoint(pointFromCoordinateJson(value.at("point")));
+            }
+            collection->append(validity);
+            continue;
+        }
+
+        if (value.contains("start") || value.contains("end")) {
+            if (!value.contains("start") || !value.contains("end")) {
+                raiseImport("Validity ranges must define both start and end.");
+            }
+            if (offsetType && *offsetType != Validity::GeoPosOffset) {
+                validity->setOffsetRange(
+                    *offsetType,
+                    value.at("start").get<double>(),
+                    value.at("end").get<double>());
+            }
+            else {
+                validity->setOffsetRange(
+                    pointFromCoordinateJson(value.at("start")),
+                    pointFromCoordinateJson(value.at("end")));
+            }
+            collection->append(validity);
+            continue;
+        }
+
+        collection->append(validity);
+    }
+}
+
+struct DeferredAttributeValidity
+{
+    model_ptr<Feature> hostFeature_;
+    model_ptr<Attribute> attribute_;
+    nlohmann::json validityJson_;
+};
+
+/** Defer relation import until every feature id in the tile has been created. */
+struct DeferredRelation
+{
+    model_ptr<Feature> feature_;
+    nlohmann::json relationJson_;
+};
+
+/** Import one attribute payload object, excluding deferred validity handling. */
+void importAttributeObject(
+    TileFeatureLayer& tile,
+    model_ptr<Feature> hostFeature,
+    model_ptr<Attribute> attribute,
+    nlohmann::json const& json,
+    GeoJsonImportOptions const& options,
+    std::vector<DeferredAttributeValidity>& deferredValidities)
+{
+    if (!json.is_object()) {
+        raiseImport(fmt::format("Attribute '{}' must be encoded as an object.", attribute->name()));
+    }
+
+    for (auto const& [key, value] : json.items()) {
+        if (key == "validity") {
+            deferredValidities.push_back(DeferredAttributeValidity{hostFeature, attribute, value});
+            continue;
+        }
+        if (key == "_sourceData" || key == "sourceData") {
+            if (auto refs = importSourceDataReferences(tile, value)) {
+                attribute->setSourceDataReferences(*refs);
+            }
+            continue;
+        }
+        auto result = attribute->addField(key, importGenericNode(tile, value));
+        if (!result) {
+            raiseImport(result.error().message);
+        }
+    }
+}
+
+/** Import feature properties and map attribute-layer payloads into their model containers. */
+void importProperties(
+    TileFeatureLayer& tile,
+    model_ptr<Feature> feature,
+    nlohmann::json const& propertiesJson,
+    GeoJsonImportOptions const& options,
+    std::vector<DeferredAttributeValidity>& deferredValidities)
+{
+    if (!propertiesJson.is_object()) {
+        raiseImport("Feature properties must be encoded as an object.");
+    }
+
+    if (auto layerIt = propertiesJson.find("layer"); layerIt != propertiesJson.end()) {
+        if (!layerIt->is_object()) {
+            raiseImport("properties.layer must be a JSON object.");
+        }
+        for (auto const& [layerName, layerValue] : layerIt->items()) {
+            if (!layerValue.is_object()) {
+                raiseImport(fmt::format("Attribute layer '{}' must be a JSON object.", layerName));
+            }
+            auto attrLayer = feature->attributeLayers()->newLayer(layerName);
+            for (auto const& [attrName, attrValue] : layerValue.items()) {
+                auto attribute = attrLayer->newAttribute(attrName);
+                importAttributeObject(tile, feature, attribute, attrValue, options, deferredValidities);
+            }
+        }
+    }
+
+    for (auto const& [key, value] : propertiesJson.items()) {
+        if (key == "layer") {
+            // `properties.layer` is reserved for exported attribute layers.
+            continue;
+        }
+        if (!options.strict_ && options.objectPropertiesAsAttributeLayers_ && value.is_object()) {
+            // Best-effort mode may reinterpret nested objects as attribute layers for plain GeoJSON.
+            auto attrLayer = feature->attributeLayers()->newLayer(key);
+            for (auto const& [attrName, attrValue] : value.items()) {
+                auto attribute = attrLayer->newAttribute(attrName);
+                if (attrValue.is_object()) {
+                    importAttributeObject(tile, feature, attribute, attrValue, options, deferredValidities);
+                }
+                else {
+                    auto result = attribute->addField(attrName, importGenericNode(tile, attrValue));
+                    if (!result) {
+                        raiseImport(result.error().message);
+                    }
+                }
+            }
+            continue;
+        }
+
+        auto result = feature->attributes()->addField(key, importGenericNode(tile, value));
+        if (!result) {
+            raiseImport(result.error().message);
+        }
+    }
+}
+
+/** Import one relation object after feature ids are already resolvable. */
+void importRelation(
+    TileFeatureLayer& tile,
+    model_ptr<Feature> feature,
+    nlohmann::json const& relationJson,
+    GeoJsonImportOptions const& options)
+{
+    if (!relationJson.is_object()) {
+        raiseImport("Every relation must be encoded as an object.");
+    }
+    if (!relationJson.contains("name") || !relationJson.contains("target")) {
+        raiseImport("Every relation must contain name and target fields.");
+    }
+
+    auto relation = tile.newRelation(
+        relationJson.at("name").get<std::string>(),
+        importFeatureReferenceId(tile, relationJson.at("target")));
+
+    if (auto sourceDataJson = findSourceDataJson(relationJson)) {
+        if (auto refs = importSourceDataReferences(tile, *sourceDataJson)) {
+            relation->setSourceDataReferences(*refs);
+        }
+    }
+    if (relationJson.contains("sourceValidity")) {
+        importValidityCollection(tile, feature, relation->sourceValidity(), relationJson.at("sourceValidity"), options);
+    }
+    if (relationJson.contains("targetValidity")) {
+        importValidityCollection(tile, feature, relation->targetValidity(), relationJson.at("targetValidity"), options);
+    }
+
+    feature->addRelation(relation);
+}
+
+/** Determine the target feature type for one imported feature. */
+[[nodiscard]] std::string determineFeatureType(
+    TileFeatureLayer const& tile,
+    nlohmann::json const& featureJson,
+    GeoJsonImportOptions const& options)
+{
+    if (auto typeIt = featureJson.find("typeId"); typeIt != featureJson.end() && typeIt->is_string()) {
+        return typeIt->get<std::string>();
+    }
+    if (options.fallbackFeatureType_) {
+        return *options.fallbackFeatureType_;
+    }
+    if (tile.layerInfo()->featureTypes_.size() == 1) {
+        return tile.layerInfo()->featureTypes_.front().name_;
+    }
+    raiseImport("Could not determine feature type. Missing 'typeId' and no fallback feature type was configured.");
+    return {};
+}
+
+}
+
+/** Import a FeatureCollection into an empty TileFeatureLayer. */
+void importGeoJson(
+    TileFeatureLayer& tile,
+    nlohmann::json const& geoJson,
+    GeoJsonImportOptions const& options)
+{
+    if (tile.numRoots() != 0) {
+        raiseImport("Import requires an empty TileFeatureLayer instance.");
+    }
+    if (tile.getIdPrefix()) {
+        // GeoJSON import now treats full ids as the canonical representation.
+        raiseImport("Import requires a TileFeatureLayer without a preconfigured idPrefix.");
+    }
+    if (!geoJson.is_object() || geoJson.value("type", "") != "FeatureCollection") {
+        raiseImport("GeoJSON root must be a FeatureCollection.");
+    }
+    if (!geoJson.contains("features") || !geoJson.at("features").is_array()) {
+        raiseImport("GeoJSON FeatureCollection is missing an array-valued 'features' field.");
+    }
+
+    if (options.strict_) {
+        if (geoJson.contains("glbAttachment")) {
+            raiseImport("GLB attachment import is not supported yet.");
+        }
+        // Strict mode treats top-level metadata mismatches as caller/configuration errors.
+        if (geoJson.contains("mapgetTileId") && geoJson.at("mapgetTileId").get<uint64_t>() != tile.tileId().value_) {
+            raiseImport("mapgetTileId does not match the target tile.");
+        }
+        if (geoJson.contains("mapId") && geoJson.at("mapId").get<std::string>() != tile.mapId()) {
+            raiseImport("mapId does not match the target tile.");
+        }
+        if (geoJson.contains("mapgetLayerId") && geoJson.at("mapgetLayerId").get<std::string>() != tile.layerInfo()->layerId_) {
+            raiseImport("mapgetLayerId does not match the target tile layer.");
+        }
+    }
+
+    if (geoJson.contains("geometryAnchor")) {
+        tile.setGeometryAnchor(pointFromCoordinateJson(geoJson.at("geometryAnchor")));
+    }
+    if (geoJson.contains("timestamp")) {
+        auto parsed = parseTimestamp(geoJson.at("timestamp").get<std::string>());
+        if (!parsed) {
+            raiseImport("Invalid timestamp format.");
+        }
+        tile.setTimestamp(*parsed);
+    }
+    if (geoJson.contains("ttl")) {
+        tile.setTtl(std::chrono::milliseconds(geoJson.at("ttl").get<int64_t>()));
+    }
+    if (geoJson.contains("error")) {
+        auto const& errorJson = geoJson.at("error");
+        if (!errorJson.is_object()) {
+            raiseImport("error must be encoded as an object.");
+        }
+        if (errorJson.contains("message")) {
+            tile.setError(errorJson.at("message").get<std::string>());
+        }
+        if (errorJson.contains("code")) {
+            tile.setErrorCode(errorJson.at("code").get<int>());
+        }
+    }
+
+    std::vector<DeferredAttributeValidity> deferredValidities;
+    std::vector<DeferredRelation> deferredRelations;
+
+    uint32_t fallbackFeatureIndex = 0;
+    for (auto const& featureJson : geoJson.at("features")) {
+        if (!featureJson.is_object()) {
+            raiseImport("Every feature entry must be a JSON object.");
+        }
+        if (featureJson.value("type", "") != "Feature") {
+            raiseImport("Every feature entry must have type 'Feature'.");
+        }
+
+        auto const typeId = determineFeatureType(tile, featureJson, options);
+        KeyValueViewPairs localIdParts;
+
+        if (options.strict_ || featureJson.contains("typeId")) {
+            auto const* typeInfo = tile.layerInfo()->getTypeInfo(typeId, false);
+            if (!typeInfo || typeInfo->uniqueIdCompositions_.empty()) {
+                raiseImport(fmt::format("Could not resolve feature type '{}' for import.", typeId));
+            }
+            auto fullIdParts = fullFeatureIdPartsFromFields(featureJson, typeInfo->uniqueIdCompositions_.front());
+            if (featureJson.contains("id")) {
+                ParsedFeatureId parsed;
+                std::string error;
+                if (!parseFeatureIdString(featureJson.at("id").get<std::string>(), *tile.layerInfo(), parsed, &error)) {
+                    raiseImport(error);
+                }
+                if (parsed.typeId_ != typeId || parsed.keyValuePairs_ != fullIdParts) {
+                    raiseImport(fmt::format("Feature id '{}' does not match explicit id-part fields.", featureJson.at("id").get<std::string>()));
+                }
+            }
+            // Strict import reconstructs the full id verbatim instead of reintroducing tile prefixes.
+            localIdParts = castToKeyValueView(fullIdParts);
+        }
+        else {
+            auto fullIdParts = bestEffortFullFeatureIdParts(tile, typeId, fallbackFeatureIndex);
+            localIdParts = castToKeyValueView(fullIdParts);
+        }
+        ++fallbackFeatureIndex;
+
+        auto feature = tile.newFeature(typeId, localIdParts);
+
+        if (auto sourceDataJson = findSourceDataJson(featureJson)) {
+            if (auto refs = importSourceDataReferences(tile, *sourceDataJson)) {
+                feature->setSourceDataReferences(*refs);
+            }
+        }
+        if (featureJson.contains("geometry")) {
+            importFeatureGeometry(tile, feature, featureJson.at("geometry"), options);
+        }
+        if (featureJson.contains("properties")) {
+            importProperties(tile, feature, featureJson.at("properties"), options, deferredValidities);
+        }
+        if (featureJson.contains("relations")) {
+            deferredRelations.push_back(DeferredRelation{feature, featureJson.at("relations")});
+        }
+    }
+
+    // Attribute validities may reference local features, so resolve them after all features exist.
+    for (auto& deferred : deferredValidities) {
+        importValidityCollection(
+            tile,
+            deferred.hostFeature_,
+            deferred.attribute_->validity(),
+            deferred.validityJson_,
+            options);
+    }
+
+    // Relations are imported last for the same reason: all target ids must already be present.
+    for (auto& deferred : deferredRelations) {
+        if (!deferred.relationJson_.is_array()) {
+            raiseImport("Feature relations must be encoded as an array.");
+        }
+        for (auto const& relationJson : deferred.relationJson_) {
+            importRelation(tile, deferred.feature_, relationJson, options);
+        }
+    }
+}
+
+void TileFeatureLayer::fromJson(nlohmann::json const& json, GeoJsonImportOptions const& options)
+{
+    importGeoJson(*this, json, options);
+}
+
+}

--- a/libs/model/src/geojson-import.cpp
+++ b/libs/model/src/geojson-import.cpp
@@ -446,22 +446,61 @@ void validateIdPartValue(
     return tile.newSourceDataReferenceCollection(refs);
 }
 
+struct ParsedFeatureReferenceJson
+{
+    ParsedFeatureId featureId_;
+    std::optional<std::string> externalMapId_;
+};
+
+/** Parse a local or external feature reference from JSON. */
+[[nodiscard]] ParsedFeatureReferenceJson parseFeatureReferenceJson(
+    TileFeatureLayer& tile,
+    nlohmann::json const& json)
+{
+    std::string canonicalId;
+    std::optional<std::string> externalMapId;
+
+    if (json.is_string()) {
+        canonicalId = json.get<std::string>();
+    }
+    else if (json.is_object()) {
+        auto const idIt = json.find("id");
+        if (idIt == json.end() || !idIt->is_string()) {
+            raiseImport("Feature reference objects must contain a string `id` field.");
+        }
+        canonicalId = idIt->get<std::string>();
+
+        if (auto mapIdIt = json.find("mapId"); mapIdIt != json.end()) {
+            if (!mapIdIt->is_string()) {
+                raiseImport("Feature reference `mapId` must be a string.");
+            }
+            externalMapId = mapIdIt->get<std::string>();
+        }
+    }
+    else {
+        raiseImport("Feature references must be encoded as canonical feature-id strings or `{id, mapId}` objects.");
+    }
+
+    ParsedFeatureReferenceJson parsed;
+    std::string error;
+    if (!parseFeatureIdString(canonicalId, *tile.layerInfo(), parsed.featureId_, &error)) {
+        raiseImport(error);
+    }
+    parsed.externalMapId_ = std::move(externalMapId);
+    return parsed;
+}
+
 /** Parse a canonical feature-id string into a detached FeatureId node. */
 [[nodiscard]] model_ptr<FeatureId> importFeatureReferenceId(
     TileFeatureLayer& tile,
     nlohmann::json const& json)
 {
-    if (!json.is_string()) {
-        raiseImport("Feature references must be encoded as canonical feature-id strings.");
-    }
-
-    ParsedFeatureId parsed;
-    std::string error;
-    if (!parseFeatureIdString(json.get<std::string>(), *tile.layerInfo(), parsed, &error)) {
-        raiseImport(error);
-    }
-    auto partsView = castToKeyValueView(parsed.keyValuePairs_);
-    return tile.newFeatureId(parsed.typeId_, partsView);
+    auto parsed = parseFeatureReferenceJson(tile, json);
+    auto partsView = castToKeyValueView(parsed.featureId_.keyValuePairs_);
+    auto externalMapId = parsed.externalMapId_
+        ? std::optional<std::string_view>(*parsed.externalMapId_)
+        : std::nullopt;
+    return tile.newFeatureId(parsed.featureId_.typeId_, partsView, externalMapId);
 }
 
 /** Resolve a canonical feature-id string to a feature already created in this tile. */
@@ -469,20 +508,18 @@ void validateIdPartValue(
     TileFeatureLayer& tile,
     nlohmann::json const& json)
 {
-    if (!json.is_string()) {
-        raiseImport("Feature transition references must be encoded as canonical feature-id strings.");
+    auto parsed = parseFeatureReferenceJson(tile, json);
+    if (parsed.externalMapId_ && *parsed.externalMapId_ != tile.mapId()) {
+        raiseImport(fmt::format(
+            "Feature transition references must stay local to map '{}'.",
+            tile.mapId()));
     }
 
-    ParsedFeatureId parsed;
-    std::string error;
-    if (!parseFeatureIdString(json.get<std::string>(), *tile.layerInfo(), parsed, &error)) {
-        raiseImport(error);
-    }
-
-    if (auto feature = tile.find(parsed.typeId_, parsed.keyValuePairs_)) {
+    if (auto feature = tile.find(parsed.featureId_.typeId_, parsed.featureId_.keyValuePairs_)) {
         return feature;
     }
-    raiseImport(fmt::format("Could not resolve local feature reference '{}'.", json.get<std::string>()));
+    auto referenceJson = json.is_string() ? json.get<std::string>() : json.dump();
+    raiseImport(fmt::format("Could not resolve local feature reference '{}'.", referenceJson));
     return {};
 }
 

--- a/libs/model/src/geojson-import.cpp
+++ b/libs/model/src/geojson-import.cpp
@@ -1036,14 +1036,14 @@ void importGeoJson(
         }
 
         auto const typeId = determineFeatureType(tile, featureJson, options);
-        KeyValueViewPairs localIdParts;
+        KeyValuePairs fullIdParts;
 
         if (options.strict_ || featureJson.contains("typeId")) {
             auto const* typeInfo = tile.layerInfo()->getTypeInfo(typeId, false);
             if (!typeInfo || typeInfo->uniqueIdCompositions_.empty()) {
                 raiseImport(fmt::format("Could not resolve feature type '{}' for import.", typeId));
             }
-            auto fullIdParts = fullFeatureIdPartsFromFields(featureJson, typeInfo->uniqueIdCompositions_.front());
+            fullIdParts = fullFeatureIdPartsFromFields(featureJson, typeInfo->uniqueIdCompositions_.front());
             if (featureJson.contains("id")) {
                 ParsedFeatureId parsed;
                 std::string error;
@@ -1055,15 +1055,14 @@ void importGeoJson(
                 }
             }
             // Strict import reconstructs the full id verbatim instead of reintroducing tile prefixes.
-            localIdParts = castToKeyValueView(fullIdParts);
         }
         else {
-            auto fullIdParts = bestEffortFullFeatureIdParts(tile, typeId, fallbackFeatureIndex);
-            localIdParts = castToKeyValueView(fullIdParts);
+            fullIdParts = bestEffortFullFeatureIdParts(tile, typeId, fallbackFeatureIndex);
         }
         ++fallbackFeatureIndex;
 
-        auto feature = tile.newFeature(typeId, localIdParts);
+        // Keep the owned strings alive while the temporary view is handed to newFeature().
+        auto feature = tile.newFeature(typeId, castToKeyValueView(fullIdParts));
 
         if (auto sourceDataJson = findSourceDataJson(featureJson)) {
             if (auto refs = importSourceDataReferences(tile, *sourceDataJson)) {

--- a/libs/model/src/geometry.cpp
+++ b/libs/model/src/geometry.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <numeric>
 #include <stdexcept>
 #include <string_view>
@@ -25,6 +26,7 @@ static const std::string_view MultiPolygonStr("MultiPolygon");
 
 namespace
 {
+/** Project a point onto a finite line segment in the x/y plane. */
 std::optional<glm::dvec3>
 projectPointOnLine(const glm::dvec3& point, const glm::dvec3& a, const glm::dvec3& b)
 {
@@ -64,6 +66,7 @@ using namespace simfil;
 
 namespace
 {
+/** Check whether a model column stores an actual geometry payload. */
 bool isBaseGeometryColumn(uint8_t column)
 {
     using Col = TileFeatureLayer::ColumnId;
@@ -75,6 +78,7 @@ bool isBaseGeometryColumn(uint8_t column)
            column == Col::GltfNodeIndexGeometries;
 }
 
+/** Map storage columns back to their logical geometry type. */
 GeomType geometryTypeForColumn(uint8_t column)
 {
     using Col = TileFeatureLayer::ColumnId;
@@ -97,6 +101,7 @@ GeomType geometryTypeForColumn(uint8_t column)
     }
 }
 
+/** Map a stored geometry stage back to the optional exported `geometryName`. */
 std::optional<std::string_view> geometryNameForStage(
     TileFeatureLayer const& model,
     std::optional<uint32_t> geometryStage)
@@ -106,6 +111,8 @@ std::optional<std::string_view> geometryNameForStage(
     }
     auto const& layerInfo = *model.layerInfo();
     if (*geometryStage <= layerInfo.highFidelityStage_) {
+        // The default high-fidelity stage is represented by the absence of a
+        // label so generic GeoJSON stays uncluttered.
         return std::nullopt;
     }
     if (*geometryStage >= layerInfo.stageLabels_.size()) {
@@ -118,11 +125,13 @@ std::optional<std::string_view> geometryNameForStage(
     return label;
 }
 
+/** Serialize one 3D coordinate triple in GeoJSON position form. */
 nlohmann::json positionJson(Point const& point)
 {
     return nlohmann::json::array({point.x, point.y, point.z});
 }
 
+/** Build the footprint polygon used to export AABB-like geometries. */
 nlohmann::json groundFootprintPolygon(Point const& origin, Point const& size)
 {
     auto const minX = origin.x;
@@ -142,6 +151,7 @@ nlohmann::json groundFootprintPolygon(Point const& origin, Point const& size)
     });
 }
 
+/** Resolve the origin of an AABB-like geometry regardless of storage flavor. */
 Point boundsOrigin(model_ptr<Geometry> const& geometry)
 {
     return geometry->geomType() == GeomType::AABB
@@ -149,6 +159,7 @@ Point boundsOrigin(model_ptr<Geometry> const& geometry)
         : geometry->gltfNodeAabbOrigin();
 }
 
+/** Resolve the size of an AABB-like geometry regardless of storage flavor. */
 Point boundsSize(model_ptr<Geometry> const& geometry)
 {
     return geometry->geomType() == GeomType::AABB
@@ -156,6 +167,7 @@ Point boundsSize(model_ptr<Geometry> const& geometry)
         : geometry->gltfNodeAabbSize();
 }
 
+/** Reinterpret a base geometry address in one of the helper-view columns. */
 ModelNodeAddress geometryHelperAddress(
     uint8_t helperColumn,
     ModelNodeAddress baseGeometryAddress)
@@ -163,11 +175,13 @@ ModelNodeAddress geometryHelperAddress(
     return {helperColumn, baseGeometryAddress.index()};
 }
 
+/** Encode the base geometry address into the helper node payload. */
 int64_t geometryHelperData(ModelNodeAddress baseGeometryAddress)
 {
     return encodeGeometryHelperData(baseGeometryAddress);
 }
 
+/** Encode base address plus point-view flavor for helper point nodes. */
 int64_t geometryPointHelperData(
     ModelNodeAddress baseGeometryAddress,
     GeometryPointViewKind pointKind)
@@ -175,6 +189,7 @@ int64_t geometryPointHelperData(
     return encodeGeometryHelperData(baseGeometryAddress, static_cast<uint8_t>(pointKind));
 }
 
+/** Create the object view that exposes origin/size for bounds geometries. */
 ModelNode::Ptr makeBoundsInfoView(
     TileFeatureLayer const& model,
     ModelNodeAddress baseGeometryAddress)
@@ -186,6 +201,7 @@ ModelNode::Ptr makeBoundsInfoView(
         geometryHelperData(baseGeometryAddress));
 }
 
+/** Create the polygon coordinate view used for AABB and GLTF-bounds export. */
 ModelNode::Ptr makeBoundsPolygonCoordinatesView(
     TileFeatureLayer const& model,
     ModelNodeAddress baseGeometryAddress)
@@ -197,6 +213,7 @@ ModelNode::Ptr makeBoundsPolygonCoordinatesView(
         geometryHelperData(baseGeometryAddress));
 }
 
+/** Create the single ring used by the bounds polygon coordinate view. */
 ModelNode::Ptr makeBoundsRingView(
     TileFeatureLayer const& model,
     ModelNodeAddress baseGeometryAddress)
@@ -208,6 +225,7 @@ ModelNode::Ptr makeBoundsRingView(
         geometryHelperData(baseGeometryAddress));
 }
 
+/** Create a procedural point view into either a bounds helper or point buffer. */
 ModelNode::Ptr makeGeometryPointView(
     TileFeatureLayer const& model,
     ModelNodeAddress baseGeometryAddress,
@@ -225,12 +243,14 @@ constexpr size_t GltfNodeAabbOriginSlot = 1;
 constexpr size_t GltfNodeAabbSizeSlot = 2;
 constexpr uint32_t MaxExactGltfNodeIndex = 1U << 24;
 
+/** Convert a geometry address to the corresponding point-buffer storage index. */
 simfil::ArrayIndex geometryBufferIndex(ModelNodeAddress geometryAddress)
 {
     return static_cast<simfil::ArrayIndex>(geometryAddress.index());
 }
 
 template <typename StorageType>
+/** Ensure GLTF node geometries expose the fixed [index, origin, size] slot layout. */
 void ensureGltfNodeStorageInitialized(StorageType& storage, simfil::ArrayIndex arrayIndex)
 {
     auto const currentSize = storage.size(arrayIndex);
@@ -534,6 +554,16 @@ std::optional<uint32_t> Geometry::stage() const
     return std::nullopt;
 }
 
+void Geometry::setStage(std::optional<uint32_t> geometryStage)
+{
+    if (geometryStage && *geometryStage > static_cast<uint32_t>(std::numeric_limits<uint8_t>::max())) {
+        raise("Geometry::setStage: stage is out of uint8_t range.");
+    }
+    model().setGeometryStage(
+        addr_,
+        geometryStage ? std::optional<uint8_t>{static_cast<uint8_t>(*geometryStage)} : std::nullopt);
+}
+
 SelfContainedGeometry Geometry::toSelfContained() const
 {
     SelfContainedGeometry result{{}, geomType()};
@@ -573,6 +603,8 @@ ModelNode::Ptr Geometry::at(int64_t i) const {
         return get(StringPool::TypeStr);
     if (i == 1)
         return get(StringPool::CoordinatesStr);
+    // AABB and GLTF-node geometries serialize as polygons plus one auxiliary
+    // metadata field so they remain consumable as GeoJSON.
     if (type == GeomType::AABB && i == 2)
         return get(StringPool::AabbStr);
     if (type == GeomType::GltfNodeIndex && i == 2)
@@ -614,9 +646,13 @@ ModelNode::Ptr Geometry::get(const StringId& f) const {
             typeName = MultiPolygonStr;
             break;
         case GeomType::AABB:
+            // Bounds-only geometries are exported as footprint polygons plus an
+            // auxiliary `aabb` object containing the full 3D extent.
             typeName = PolygonStr;
             break;
         case GeomType::GltfNodeIndex:
+            // GLTF node references also export their bounds footprint so generic
+            // GeoJSON consumers can still place them spatially.
             typeName = PolygonStr;
             break;
         }
@@ -636,12 +672,15 @@ ModelNode::Ptr Geometry::get(const StringId& f) const {
             return makeBoundsPolygonCoordinatesView(model(), addr_);
         case GeomType::Polygon:
             if (geomViewData_) {
+                // Geometry views may expose only a point subrange, so they fall
+                // back to the generic point-buffer view instead of polygon rings.
                 break;
             }
             return model().resolve(
                 ModelNodeAddress{TileFeatureLayer::ColumnId::Polygon, addr_.index()});
         case GeomType::Mesh:
             if (geomViewData_) {
+                // Same for mesh views: only base meshes can present triangle collections.
                 break;
             }
             return model().resolve(
@@ -698,11 +737,14 @@ void Geometry::append(Point const& p)
 
     glm::vec3 storedPoint{};
     if (geomType() == GeomType::AABB && storage_->size(static_cast<simfil::ArrayIndex>(addr_.index())) == 1) {
+        // The second AABB slot stores size, not another anchor-relative point.
         storedPoint = glm::vec3{
             static_cast<float>(p.x),
             static_cast<float>(p.y),
             static_cast<float>(p.z)};
     } else {
+        // Regular geometry vertices are stored relative to the tile anchor to
+        // preserve precision while keeping the on-disk representation compact.
         auto const anchor = model().geometryAnchor();
         storedPoint = glm::vec3{
             static_cast<float>(p.x - anchor.x),
@@ -725,6 +767,8 @@ void Geometry::setAabb(Point const& origin, Point const& size)
     auto const arrayIndex = static_cast<simfil::ArrayIndex>(addr_.index());
     auto const currentSize = storage_->size(arrayIndex);
     if (currentSize == 0) {
+        // New AABBs reuse append() so the special origin/size storage layout is
+        // applied consistently.
         append(origin);
         append(size);
         return;
@@ -780,6 +824,8 @@ void Geometry::setGltfNodeIndex(uint32_t index)
         raise("Cannot mutate geometry view.");
     }
     if (index > MaxExactGltfNodeIndex) {
+        // The node index lives in a float-backed storage slot, so only integers
+        // within the exact mantissa range are lossless.
         raiseFmt(
             "GLTF node index {} exceeds the exact float storage limit of {}.",
             index,
@@ -882,6 +928,8 @@ bool Geometry::iterate(const IterCallback& cb) const
 size_t Geometry::numPoints() const
 {
     if (geomType() == GeomType::GltfNodeIndex) {
+        // GLTF node geometries expose only their node id and bounds; they do
+        // not behave like a coordinate buffer.
         return 0;
     }
     auto vertexBufferNode = model_ptr<PointBufferNode>::make(model_, addr_);
@@ -900,6 +948,8 @@ Point Geometry::pointAt(size_t index) const
 double Geometry::length() const
 {
     if (geomType() == GeomType::GltfNodeIndex || geomType() == GeomType::AABB) {
+        // Bounds-only geometries and GLTF node references do not define a
+        // traversable line length.
         return 0.0;
     }
     auto length = 0.0;
@@ -1043,6 +1093,8 @@ Point Geometry::percentagePositionFromGeometries(std::vector<model_ptr<Geometry>
             percentagePosition -= lengths[i];
         }
         else {
+            // Once the target falls into a segment geometry, reuse the
+            // length-bound sampling helper to get the final point.
             auto points = geoms[i]->pointsFromLengthBound(percentagePosition, std::nullopt);
             if (points.empty()) {
                 break;
@@ -1473,6 +1525,8 @@ PointBufferNode::PointBufferNode(
         baseGeomAddress_ = viewData->baseGeometry_;
 
         while (baseGeomAddress_.column() == TileFeatureLayer::ColumnId::GeometryViews) {
+            // Nested views accumulate offsets until a real base geometry buffer
+            // is reached, so point access stays O(1) afterwards.
             viewData = model().geometryViewData(baseGeomAddress_);
             if (!viewData) {
                 throw std::runtime_error("Failed to resolve nested geometry view.");

--- a/libs/model/src/info.cpp
+++ b/libs/model/src/info.cpp
@@ -13,12 +13,14 @@ namespace mapget
 
 namespace {
 
+/** Standardize missing-field errors across model metadata JSON parsers. */
 auto missing_field(std::string const& error, std::string const& context) {
     return std::runtime_error(
         fmt::format("{}::fromJson(): `{}`", context, error));
 }
 
 template <class T, class... Args>
+/** Parse a full string into a number and reject trailing characters. */
 std::optional<T> from_chars(std::string_view s, Args... args)
 {
     auto end = s.data() + s.size();
@@ -164,6 +166,9 @@ std::optional<uint32_t> IdPart::compositionMatchEndIndex(
         // Does this ID part's field name match?
         if (compositionIter->idPartLabel_ != idPartKey) {
             if (compositionIter->isOptional_) {
+                // Optional composition slots may be absent entirely, so keep
+                // scanning until we either find the requested part or hit a
+                // required mismatch.
                 ++compositionIter;
                 continue;
             }
@@ -208,6 +213,8 @@ bool IdPart::idPartsMatchComposition(
         auto compositionIter = candidateComposition.begin() + *matchEndIndex;
         while (compositionIter != candidateComposition.end()) {
             if (!compositionIter->isOptional_) {
+                // Exact feature ids must consume every remaining required part
+                // of the composition. Only optional tail fields may be omitted.
                 return false;
             }
             ++compositionIter;
@@ -223,7 +230,8 @@ bool IdPart::validate(std::variant<int64_t, std::string>& val, std::string* erro
         auto& strVal = std::get<std::string>(val);
         auto result = std::variant<int64_t, std::string_view>(strVal);
         auto resultBool = validate(result, error);
-        // The string value may have been turned into an integer.
+        // Numeric id parts accept string input during parsing, but normalize to
+        // integers once validation succeeds.
         if (std::holds_alternative<int64_t>(result)) {
             val = std::get<int64_t>(result);
         }
@@ -279,6 +287,8 @@ bool IdPart::validate(std::variant<int64_t, std::string_view>& val, std::string*
 
     auto expectUuid128 = [&expectString]() -> bool {
         return expectString([](auto const& strVal, auto error){
+            // UUID128 ids are stored as the mapget-specific 16-character token,
+            // not a hyphenated RFC 4122 string.
             if (strVal.size() != 16) {
                 if (error)
                     *error = fmt::format("Value for {} must have 16 characters!", strVal);
@@ -345,11 +355,24 @@ Coverage Coverage::fromJson(const nlohmann::json& j)
 {
     try {
         if (j.is_number_unsigned())
+            // A bare integer is shorthand for a single covered tile.
             return {
                 j.get<uint64_t>(),
                 j.get<uint64_t>(),
                 std::vector<bool>()
             };
+        if (j.is_number_integer()) {
+            // YAML ingestion may materialize the same shorthand as a signed
+            // integer, so accept it as long as the tile id stays non-negative.
+            auto tileId = j.get<int64_t>();
+            if (tileId < 0)
+                raise("Coverage tile ID must be non-negative.");
+            return {
+                static_cast<uint64_t>(tileId),
+                static_cast<uint64_t>(tileId),
+                std::vector<bool>()
+            };
+        }
         return {
             TileId(j.at("min").get<uint64_t>()),
             TileId(j.at("max").get<uint64_t>()),
@@ -388,6 +411,8 @@ std::shared_ptr<LayerInfo> LayerInfo::fromJson(const nlohmann::json& j, std::str
         const auto stages = std::max<uint32_t>(1U, j.value("stages", 1U));
         auto stageLabels = j.value("stageLabels", std::vector<std::string>{});
         if (stageLabels.size() < stages) {
+            // Import pads missing labels so stage index -> label lookup remains
+            // total even when metadata only names a few stages explicitly.
             stageLabels.reserve(stages);
             for (uint32_t i = static_cast<uint32_t>(stageLabels.size()); i < stages; ++i) {
                 stageLabels.emplace_back(fmt::format("Stage {}", i));
@@ -397,6 +422,8 @@ std::shared_ptr<LayerInfo> LayerInfo::fromJson(const nlohmann::json& j, std::str
         const auto highFidelityStage = std::min<uint32_t>(
             stages - 1U,
             j.value("highFidelityStage", defaultHighFidelityStage));
+        // High-fidelity stage is clamped into the configured stage range so
+        // downstream geometry-name lookups never index past the metadata.
 
         return std::make_shared<LayerInfo>(LayerInfo{
             j.value("layerId", layerId),
@@ -482,6 +509,8 @@ std::optional<uint8_t> LayerInfo::matchingFeatureIdCompositionIndex(
         // References may use alternative ID compositions,
         // but the feature itself must always use the first (primary) one.
         if (validateForNewFeature)
+            // Once the primary composition failed, later alternatives are not
+            // considered for concrete feature creation.
             return std::nullopt;
     }
 
@@ -521,6 +550,8 @@ DataSourceInfo DataSourceInfo::fromJson(const nlohmann::json& j)
         if (j.contains("nodeId"))
             nodeId = j.at("nodeId").get<std::string>();
         else
+            // Datasource metadata may omit a stable node id for ad-hoc JSON
+            // sources, so synthesize one to keep string-pool ownership valid.
             nodeId = generateNodeHexUuid();
 
         return {

--- a/libs/model/src/json-compare.cpp
+++ b/libs/model/src/json-compare.cpp
@@ -1,0 +1,227 @@
+#include "mapget/model/json-compare.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <sstream>
+
+namespace mapget
+{
+namespace
+{
+
+/** Recursively compare JSON values while collecting path-qualified errors. */
+bool compareJsonWithToleranceImpl(
+    nlohmann::json const& expected,
+    nlohmann::json const& actual,
+    std::string const& path,
+    double floatTolerance,
+    std::vector<std::string>* errors)
+{
+    auto const currentPath = path.empty() ? "$" : path;
+
+    if ((expected.type() != actual.type()) && !(expected.is_number() && actual.is_number())) {
+        if (errors) {
+            errors->push_back(
+                "Type mismatch at " + currentPath + ": " + expected.type_name() + " vs " +
+                actual.type_name());
+        }
+        return false;
+    }
+
+    if (expected.is_number() && actual.is_number()) {
+        if (!expected.is_number_float() && !actual.is_number_float()) {
+            // Keep integer-only comparisons exact so id-like fields do not silently drift.
+            if (expected != actual) {
+                if (errors) {
+                    errors->push_back(
+                        "Value mismatch at " + currentPath + ": " + expected.dump() + " vs " +
+                        actual.dump());
+                }
+                return false;
+            }
+            return true;
+        }
+
+        // Float-vs-float and int-vs-float comparisons are normalized through double tolerance.
+        if (!nearlyEqual(expected.get<double>(), actual.get<double>(), floatTolerance)) {
+            if (errors) {
+                std::ostringstream message;
+                message << "Float mismatch at " << currentPath << ": " << expected.get<double>()
+                        << " vs " << actual.get<double>();
+                errors->push_back(message.str());
+            }
+            return false;
+        }
+        return true;
+    }
+
+    switch (expected.type()) {
+    case nlohmann::json::value_t::object: {
+        auto matches = true;
+        if (expected.size() != actual.size()) {
+            if (errors) {
+                errors->push_back(
+                    "Object size mismatch at " + currentPath + ": " +
+                    std::to_string(expected.size()) + " vs " + std::to_string(actual.size()));
+            }
+            matches = false;
+        }
+
+        for (auto const& item : expected.items()) {
+            auto const childPath = currentPath + "." + item.key();
+            auto actualIt = actual.find(item.key());
+            if (actualIt == actual.end()) {
+                if (errors) {
+                    errors->push_back("Missing key at " + childPath);
+                }
+                matches = false;
+                continue;
+            }
+            matches = compareJsonWithToleranceImpl(
+                          item.value(),
+                          *actualIt,
+                          childPath,
+                          floatTolerance,
+                          errors) &&
+                      matches;
+        }
+        return matches;
+    }
+    case nlohmann::json::value_t::array: {
+        if (expected.size() != actual.size()) {
+            if (errors) {
+                errors->push_back(
+                    "Array size mismatch at " + currentPath + ": " +
+                    std::to_string(expected.size()) + " vs " + std::to_string(actual.size()));
+            }
+            return false;
+        }
+
+        auto matches = true;
+        for (size_t i = 0; i < expected.size(); ++i) {
+            matches = compareJsonWithToleranceImpl(
+                          expected[i],
+                          actual[i],
+                          currentPath + "[" + std::to_string(i) + "]",
+                          floatTolerance,
+                          errors) &&
+                      matches;
+        }
+        return matches;
+    }
+    default:
+        if (expected != actual) {
+            if (errors) {
+                errors->push_back(
+                    "Value mismatch at " + currentPath + ": " + expected.dump() + " vs " +
+                    actual.dump());
+            }
+            return false;
+        }
+        return true;
+    }
+}
+
+}  // namespace
+
+/** Compare floats robustly across quantization and serialization roundtrips. */
+bool nearlyEqual(double a, double b, double epsilon)
+{
+    auto const absA = std::abs(a);
+    auto const absB = std::abs(b);
+    auto const diff = std::abs(a - b);
+
+    if (a == b) {
+        return true;
+    }
+    if (a == 0.0 || b == 0.0 || diff < std::numeric_limits<double>::min()) {
+        // Near zero, pure relative error becomes unstable, so fall back to absolute error.
+        return diff < epsilon;
+    }
+
+    auto const relDiff = diff / std::min((absA + absB), std::numeric_limits<double>::max());
+    return relDiff < epsilon;
+}
+
+/** Public entry point for tolerant full-document comparison. */
+bool compareJsonWithTolerance(
+    nlohmann::json const& expected,
+    nlohmann::json const& actual,
+    double floatTolerance,
+    std::vector<std::string>* errors)
+{
+    return compareJsonWithToleranceImpl(expected, actual, "", floatTolerance, errors);
+}
+
+/** Public entry point that compares only per-feature payloads. */
+bool compareFeatureCollectionJsonWithTolerance(
+    nlohmann::json const& expected,
+    nlohmann::json const& actual,
+    double floatTolerance,
+    std::vector<std::string>* errors)
+{
+    if (!expected.contains("features") || !actual.contains("features")) {
+        if (errors) {
+            errors->push_back("Both JSON values must contain a top-level 'features' array.");
+        }
+        return false;
+    }
+    if (!expected["features"].is_array() || !actual["features"].is_array()) {
+        if (errors) {
+            errors->push_back("Top-level 'features' must be arrays.");
+        }
+        return false;
+    }
+    if (expected["features"].size() != actual["features"].size()) {
+        if (errors) {
+            errors->push_back(
+                "Feature array size mismatch: " + std::to_string(expected["features"].size()) +
+                " vs " + std::to_string(actual["features"].size()));
+        }
+        return false;
+    }
+
+    auto matches = true;
+    for (size_t i = 0; i < expected["features"].size(); ++i) {
+        auto const& expectedFeature = expected["features"][i];
+        auto const& actualFeature = actual["features"][i];
+        auto const featureId =
+            expectedFeature.contains("id") && expectedFeature["id"].is_string()
+                ? expectedFeature["id"].get<std::string>()
+                : std::string("<feature-without-id>");
+
+        std::vector<std::string> featureErrors;
+        auto const featureMatches = compareJsonWithToleranceImpl(
+            expectedFeature,
+            actualFeature,
+            "$.features[" + std::to_string(i) + "]",
+            floatTolerance,
+            &featureErrors);
+        if (!featureMatches) {
+            matches = false;
+            if (errors) {
+                // Prefix child errors with feature identity so large snapshots stay debuggable.
+                for (auto const& error : featureErrors) {
+                    errors->push_back(
+                        "Feature " + featureId + " at index " + std::to_string(i) + ": " +
+                        error);
+                }
+            }
+        }
+    }
+
+    return matches;
+}
+
+/** Render collected comparison errors into test-friendly multiline output. */
+std::string formatJsonComparisonErrors(std::vector<std::string> const& errors)
+{
+    std::ostringstream output;
+    for (auto const& error : errors) {
+        output << error << '\n';
+    }
+    return output.str();
+}
+
+}

--- a/libs/model/src/relation.cpp
+++ b/libs/model/src/relation.cpp
@@ -38,7 +38,7 @@ Relation::Relation(Relation::Data* data,
         fields_.emplace_back(
             StringPool::TargetStr,
             [](Relation const& self) {
-                return self.target()->jsonReferenceNode();
+                return self.target();
             });
     if (data_->sourceValidity_)
         fields_.emplace_back(

--- a/libs/model/src/relation.cpp
+++ b/libs/model/src/relation.cpp
@@ -38,7 +38,7 @@ Relation::Relation(Relation::Data* data,
         fields_.emplace_back(
             StringPool::TargetStr,
             [](Relation const& self) {
-                return self.model().resolve(self.data_->targetFeatureId_);
+                return self.target()->jsonReferenceNode();
             });
     if (data_->sourceValidity_)
         fields_.emplace_back(

--- a/libs/model/src/stream.cpp
+++ b/libs/model/src/stream.cpp
@@ -38,10 +38,14 @@ void TileLayerStream::Reader::read(const std::string_view& bytes)
     while (continueReading()) {}
 
     if (readOffset_ == buffer_.size()) {
+        // Fully consumed buffers are reset eagerly so long-running streams do
+        // not retain capacity proportional to peak message size.
         buffer_.clear();
         readOffset_ = 0;
     }
     else if (readOffset_ > 65536 && (readOffset_ * 2 > buffer_.size())) {
+        // For partial consumption, compact only once the consumed prefix is
+        // large enough to pay for the memmove.
         buffer_.erase(
             buffer_.begin(),
             buffer_.begin() + static_cast<std::ptrdiff_t>(readOffset_));
@@ -58,6 +62,8 @@ bool TileLayerStream::Reader::continueReading()
 {
     if (currentPhase_ == Phase::ReadHeader)
     {
+        // The stream is framed, so parsing alternates strictly between header
+        // and payload phases until the current message is complete.
         size_t headerBytesRead = 0;
         auto unreadBytes = std::span<const uint8_t>(buffer_).subspan(readOffset_);
         if (readMessageHeader(unreadBytes, nextValueType_, nextValueSize_, &headerBytesRead)) {
@@ -99,6 +105,8 @@ bool TileLayerStream::Reader::continueReading()
     }
     else if (nextValueType_ == MessageType::StringPool)
     {
+        // String-pool updates are applied in-band so subsequent layer payloads
+        // in the same stream can resolve freshly introduced string ids.
         size_t nodeIdBytesRead = 0;
         auto stringPoolNodeId = StringPool::readDataSourceNodeId(payload, 0, &nodeIdBytesRead);
         auto result = stringPoolProvider_->getStringPool(stringPoolNodeId)->read(payload, nodeIdBytesRead);
@@ -141,6 +149,8 @@ bool TileLayerStream::Reader::readMessageHeader(
             static_cast<std::underlying_type_t<bitsery::ReaderError>>(s.adapter().error())));
     }
     if (!protocolVersion.isCompatible(CurrentProtocolVersion)) {
+        // Stream compatibility is defined at the Version major/minor level.
+        // Patch releases may still exchange the same wire format.
         raise(fmt::format(
             "Unable to read message with version {} using version {}.",
             protocolVersion.toString(),
@@ -172,13 +182,17 @@ void TileLayerStream::Writer::write(TileLayer::Ptr const& tileLayer)
 
             if (highestStringKnownToClient < highestString)
             {
-                // Need to send the client an update for the string pool.
+                // String pools are streamed ahead of tile payloads so ids inside
+                // the upcoming layer bytes are immediately resolvable client-side.
                 std::string serializedStrings;
                 serializedStrings.reserve(1024); // Pre-allocate for typical string pool update
                 {
                     std::ostringstream stringsStream;
                     auto stringUpdateOffset = 0;
                     if (differentialStringUpdates_)
+                        // Differential mode sends only strings the client has
+                        // not acknowledged yet; caches must disable this and
+                        // store complete pools instead.
                         stringUpdateOffset = highestStringKnownToClient + 1;
                     strings->write(stringsStream, stringUpdateOffset);
                     serializedStrings = stringsStream.str();
@@ -210,6 +224,7 @@ void TileLayerStream::Writer::write(TileLayer::Ptr const& tileLayer)
         case mapget::LayerType::SourceData:
             return MessageType::TileSourceDataLayer;
         default:
+            // Other layer types currently have no binary stream encoding.
             raiseFmt("Unsupported layer type: {}", static_cast<int>(layerType));
         }
         return MessageType::None;
@@ -221,7 +236,7 @@ void TileLayerStream::Writer::write(TileLayer::Ptr const& tileLayer)
 void TileLayerStream::Writer::sendMessage(std::string&& bytes, TileLayerStream::MessageType msgType)
 {
     // TODO refactor the preparation of tile layer & field dicts storage format
-    //  such that the encoding logic is not split over multiple functions.
+    // such that the encoding logic is not split over multiple functions.
 
     // Calculate actual header size
     // Protocol version: ~10 bytes (depending on version object size)
@@ -245,7 +260,8 @@ void TileLayerStream::Writer::sendMessage(std::string&& bytes, TileLayerStream::
         message = headerStream.str();
     }
     
-    // Append content with move semantics
+    // Append the framed payload bytes after the header to produce one contiguous
+    // message for the caller's transport layer.
     message.append(std::move(bytes));
     
     // Send with move semantics
@@ -267,8 +283,9 @@ std::shared_ptr<StringPool> TileLayerStream::StringPoolCache::getStringPool(cons
         }
     }
     {
-        std::unique_lock stringPoolWriteLock(stringPoolCacheMutex_, std::defer_lock);
-        // Was it inserted already now?
+        std::unique_lock stringPoolWriteLock(stringPoolCacheMutex_);
+        // Another thread may have populated the cache between the shared-read
+        // miss and taking the write lock, so check again before inserting.
         auto it = stringPoolPerNodeId_.find(std::string(nodeId));
         if (it != stringPoolPerNodeId_.end())
             return it->second;

--- a/libs/model/src/validity.cpp
+++ b/libs/model/src/validity.cpp
@@ -367,7 +367,7 @@ Validity::Validity(Validity::Data* data,
             StringPool::FeatureIdStr,
             [](Validity const& self)
             {
-                return self.featureId()->jsonReferenceNode();
+                return self.featureId();
             });
     }
 }

--- a/libs/model/src/validity.cpp
+++ b/libs/model/src/validity.cpp
@@ -367,9 +367,7 @@ Validity::Validity(Validity::Data* data,
             StringPool::FeatureIdStr,
             [](Validity const& self)
             {
-                return model_ptr<simfil::ValueNode>::make(
-                    self.featureId()->toString(),
-                    self.model_);
+                return self.featureId()->jsonReferenceNode();
             });
     }
 }

--- a/libs/model/src/validity.cpp
+++ b/libs/model/src/validity.cpp
@@ -11,6 +11,7 @@ namespace mapget
 
 namespace
 {
+/** Convert a validity direction enum into the exported JSON token. */
 std::string_view directionToString(Validity::Direction const& d)
 {
     switch (d) {
@@ -23,6 +24,7 @@ std::string_view directionToString(Validity::Direction const& d)
     return "?";
 }
 
+/** Convert a transition endpoint enum into the exported JSON token. */
 std::string_view transitionEndToString(Validity::TransitionEnd const& end)
 {
     switch (end) {
@@ -32,6 +34,7 @@ std::string_view transitionEndToString(Validity::TransitionEnd const& end)
     return "?";
 }
 
+/** Pack both transition endpoint flags into the compact stored bitfield. */
 uint8_t packTransitionEnds(
     Validity::TransitionEnd fromConnectedEnd,
     Validity::TransitionEnd toConnectedEnd)
@@ -41,16 +44,19 @@ uint8_t packTransitionEnds(
         (static_cast<uint8_t>(toConnectedEnd) << 1U));
 }
 
+/** Decode the source endpoint from the stored transition bitfield. */
 Validity::TransitionEnd unpackFromConnectedEnd(uint8_t packedEnds)
 {
     return (packedEnds & 0x1U) != 0 ? Validity::End : Validity::Start;
 }
 
+/** Decode the target endpoint from the stored transition bitfield. */
 Validity::TransitionEnd unpackToConnectedEnd(uint8_t packedEnds)
 {
     return (packedEnds & 0x2U) != 0 ? Validity::End : Validity::Start;
 }
 
+/** Pick the line geometry that should be used for line-based validity resolution. */
 model_ptr<Geometry> resolveLineGeometry(
     model_ptr<GeometryCollection> const& geometryCollection,
     std::optional<uint32_t> referencedStage)
@@ -67,11 +73,13 @@ struct TransitionSegment
     Point inner_;
 };
 
+/** Compare two validity points with a small tolerance to absorb numeric noise. */
 bool pointsCoincide(Point const& left, Point const& right)
 {
     return left.distanceTo(right) < 1e-9;
 }
 
+/** Resolve the endpoint segment that participates in a semantic feature transition. */
 std::optional<TransitionSegment> resolveTransitionSegment(
     model_ptr<Feature> const& feature,
     Validity::TransitionEnd connectedEnd,
@@ -91,6 +99,8 @@ std::optional<TransitionSegment> resolveTransitionSegment(
     auto outerIndex = innerIndex;
     auto const innerPoint = geometry->pointAt(innerIndex);
     if (connectedEnd == Validity::End) {
+        // Transition endpoints may be repeated at the tail, so walk backwards
+        // until the first distinct point to get a visible outgoing segment.
         for (auto pointIndex = innerIndex; pointIndex-- > 0;) {
             if (!pointsCoincide(geometry->pointAt(pointIndex), innerPoint)) {
                 outerIndex = pointIndex;
@@ -98,6 +108,8 @@ std::optional<TransitionSegment> resolveTransitionSegment(
             }
         }
     } else {
+        // Likewise, repeated points at the head must be skipped when entering
+        // a transition from the start of a polyline.
         for (auto pointIndex = innerIndex + 1U; pointIndex < numPoints; ++pointIndex) {
             if (!pointsCoincide(geometry->pointAt(pointIndex), innerPoint)) {
                 outerIndex = pointIndex;
@@ -111,16 +123,20 @@ std::optional<TransitionSegment> resolveTransitionSegment(
     };
 }
 
+/** Apply direction semantics to a resolved geometry after the shape has been computed. */
 SelfContainedGeometry applyDirectionToGeometry(
     SelfContainedGeometry geometry,
     Validity::Direction direction)
 {
     if (direction == Validity::Negative && geometry.points_.size() > 1) {
+        // Negative direction reuses the same geometric support but traverses it
+        // against the feature digitization order.
         std::reverse(geometry.points_.begin(), geometry.points_.end());
     }
     return geometry;
 }
 
+/** Map a stored geometry stage back to the optional exported `geometryName`. */
 std::optional<std::string_view> geometryNameForStage(
     TileFeatureLayer const& model,
     std::optional<uint32_t> geometryStage)
@@ -130,6 +146,7 @@ std::optional<std::string_view> geometryNameForStage(
     }
     auto const& layerInfo = *model.layerInfo();
     if (*geometryStage <= layerInfo.highFidelityStage_) {
+        // High-fidelity geometries intentionally omit a stage label in JSON.
         return std::nullopt;
     }
     if (*geometryStage >= layerInfo.stageLabels_.size()) {
@@ -155,6 +172,8 @@ void Validity::ensureMaterialized()
         raise("Cannot materialize validity from non-simple address.");
     }
 
+    // Simple direction-only validities are stored as tiny singleton nodes and
+    // upgraded lazily only when a richer validity payload is needed.
     auto upgradedAddress = model().materializeSimpleValidity(simpleAddress, simpleDirection_);
     auto upgraded = model().resolve<Validity>(upgradedAddress);
     if (!upgraded || !upgraded->data_) {
@@ -231,6 +250,8 @@ Validity::Validity(Validity::Data* data,
     }
 
     if (data_->geomDescrType_ == SimpleGeometry) {
+        // SimpleGeometry stores an explicit geometry node, so no offset or
+        // transition metadata fields are exposed in the JSON view.
         fields_.emplace_back(
             StringPool::GeometryStr,
             [](Validity const& self)
@@ -242,6 +263,8 @@ Validity::Validity(Validity::Data* data,
     }
 
     if (data_->geomDescrType_ == FeatureTransition) {
+        // Semantic transitions serialize as feature references plus endpoint
+        // metadata instead of an explicit geometry payload.
         fields_.emplace_back(
             StringPool::TransitionNumberStr,
             [](Validity const& self)
@@ -304,6 +327,8 @@ Validity::Validity(Validity::Data* data,
             });
     }
 
+    // Offset-point and offset-range validities share the same storage; the
+    // exported field names depend on the selected offset interpretation.
     auto exposeOffsetPoint = [this](StringId fieldName, uint32_t pointIndex, Point const& p)
     {
         fields_.emplace_back(
@@ -643,7 +668,8 @@ SelfContainedGeometry Validity::computeGeometry(
         return {};
     }
 
-    // Resolve validity geometry by stage first (if specified), then by line type.
+    // Line-based validities always resolve against the preferred line geometry
+    // for the chosen stage, not against arbitrary polygons or meshes.
     auto geometry = resolveLineGeometry(geometryCollection, referencedStage);
 
     if (!geometry) {
@@ -712,6 +738,8 @@ SelfContainedGeometry Validity::computeGeometry(
         }
 
         if (endPointIndex < startPointIndex) {
+            // Buffer indices are treated as an inclusive range independent of
+            // authoring order, so normalize to ascending storage order first.
             std::swap(startPointIndex, endPointIndex);
         }
 

--- a/libs/pymapget/binding/py-layer.h
+++ b/libs/pymapget/binding/py-layer.h
@@ -165,14 +165,28 @@ void bindTileLayer(py::module_& m)
         )pbdoc")
         .def(
             "new_feature_id",
-            [](TileFeatureLayer& self, std::string const& typeId, KeyValuePairVec const& idParts)
-            { return BoundFeatureId(self.newFeatureId(typeId, castToKeyValueView(idParts))); },
+            [](TileFeatureLayer& self,
+               std::string const& typeId,
+               KeyValuePairVec const& idParts,
+               std::optional<std::string> const& mapId)
+            {
+                auto externalMapId = mapId
+                    ? std::optional<std::string_view>(*mapId)
+                    : std::nullopt;
+                return BoundFeatureId(
+                    self.newFeatureId(
+                        typeId,
+                        castToKeyValueView(idParts),
+                        externalMapId));
+            },
             py::arg("type_id"),
             py::arg("feature_id_parts"),
+            py::arg("map_id") = py::none(),
             R"pbdoc(
             Create a new feature id. Use this function to create a reference to another
             feature. The created feature id will not use the common feature id prefix
-            from this tile feature layer.
+            from this tile feature layer. Pass `map_id` to reference a feature in
+            another map.
         )pbdoc")
         .def(
             "new_attribute",

--- a/libs/pymapget/binding/py-model.h
+++ b/libs/pymapget/binding/py-model.h
@@ -565,7 +565,15 @@ struct BoundFeatureId : public BoundModelNode
             .def(
                 "type_id",
                 [](BoundFeatureId& self) { return self.modelNodePtr_->typeId(); },
-                "Get the feature ID's type ID.");
+                "Get the feature ID's type ID.")
+            .def(
+                "map_id",
+                [](BoundFeatureId& self) { return self.modelNodePtr_->mapId(); },
+                "Get the effective map ID referenced by this feature ID.")
+            .def(
+                "external_map_id",
+                [](BoundFeatureId& self) { return self.modelNodePtr_->externalMapId(); },
+                "Get the explicitly stored external map ID, or None for local references.");
     }
 
     ModelNode::Ptr node() override { return modelNodePtr_; }

--- a/libs/service/include/mapget/service/config.h
+++ b/libs/service/include/mapget/service/config.h
@@ -5,6 +5,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <mutex>
 #include <map>
@@ -202,6 +203,14 @@ nlohmann::json yamlToJson(
     bool maskSecrets,
     std::unordered_map<std::string, std::string>* maskedSecretMap = nullptr,
     bool maskCurrentNode = false);
+
+/** Parse a YAML or JSON document from a string buffer into JSON. */
+[[nodiscard]] nlohmann::json parseStructuredDocument(
+    std::string_view content,
+    std::string_view sourceName = "<memory>");
+
+/** Load and parse a YAML or JSON document from disk into JSON. */
+[[nodiscard]] nlohmann::json loadStructuredDocumentFile(std::string const& path);
 
 /** Convert JSON to YAML, resolving masked secrets if provided. */
 YAML::Node jsonToYaml(

--- a/libs/service/src/config.cpp
+++ b/libs/service/src/config.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <chrono>
 #include <algorithm>
+#include <cctype>
 #include <nlohmann/json-schema.hpp>
 #include <fmt/format.h>
 
@@ -276,6 +277,53 @@ nlohmann::json yamlToJson(
 
     log().warn("Could not convert {} to JSON!", YAML::Dump(yamlNode));
     return {};
+}
+
+nlohmann::json parseStructuredDocument(
+    std::string_view content,
+    std::string_view sourceName)
+{
+    auto trimmed = content;
+    while (!trimmed.empty() && std::isspace(static_cast<unsigned char>(trimmed.front())))
+        trimmed.remove_prefix(1);
+    while (!trimmed.empty() && std::isspace(static_cast<unsigned char>(trimmed.back())))
+        trimmed.remove_suffix(1);
+
+    if (trimmed.empty()) {
+        raise(fmt::format("Structured document `{}` is empty.", sourceName));
+    }
+
+    if (trimmed.front() == '{' || trimmed.front() == '[') {
+        try {
+            return nlohmann::json::parse(trimmed);
+        }
+        catch (const std::exception&) {
+            // Fall back to YAML parsing below. YAML is a superset of JSON,
+            // so this keeps error handling consistent for malformed input.
+        }
+    }
+
+    try {
+        return yamlToJson(YAML::Load(std::string(content)), false);
+    }
+    catch (const YAML::Exception& e) {
+        raise(fmt::format(
+            "Failed to parse structured document `{}` as YAML or JSON: {}",
+            sourceName,
+            e.what()));
+    }
+}
+
+nlohmann::json loadStructuredDocumentFile(std::string const& path)
+{
+    std::ifstream file(path);
+    if (!file) {
+        raise(fmt::format("Failed to open structured document file `{}`.", path));
+    }
+
+    std::ostringstream buffer;
+    buffer << file.rdbuf();
+    return parseStructuredDocument(buffer.str(), path);
 }
 
 YAML::Node jsonToYaml(

--- a/test/integration/mapget-exec-datasource.bash
+++ b/test/integration/mapget-exec-datasource.bash
@@ -5,8 +5,9 @@ set -euo
 src_dir="$(cd "$(dirname "$0")" && pwd)/../.."
 example_dir="$src_dir/examples"
 
-if [[ "$OSTYPE" == "msys" ]]; then
-  # On Windows, convert path from /c/Users to C:/Users so python understands it.
+if command -v cygpath >/dev/null 2>&1; then
+  # On Windows-hosted bash variants, normalize /c/... or /d/... paths into a
+  # form the native Python executable understands.
   example_dir=$(cygpath -m "$example_dir")
 fi
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(test.mapget
   test-cache.cpp
   test-service-ttl.cpp
   test-config.cpp
+  test-geojson-import.cpp
   test-geojsonsource.cpp
   utility.cpp
   utility.h)

--- a/test/unit/data/large-geojson-featureset.feature-collection.json
+++ b/test/unit/data/large-geojson-featureset.feature-collection.json
@@ -1,0 +1,7263 @@
+{
+  "features": [
+    {
+      "_sourceData": [
+        {
+          "address": 37795712204830,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 4294967296024,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.0,
+            48.0,
+            0.0
+          ],
+          [
+            11.000450134277344,
+            48.000221252441406,
+            0.0
+          ],
+          [
+            11.000900268554688,
+            48.00043869018555,
+            0.0
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.0",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-000",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-0",
+                  "b-0"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.0",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.1",
+                "toConnectedEnd": "START",
+                "transitionNumber": 1
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": null,
+        "rank": 0,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.0
+        }
+      },
+      "recordId": 0,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 26628797235228,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.1",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.000200271606445,
+              48.000099182128906,
+              0.0
+            ]
+          }
+        },
+        {
+          "name": "shadow",
+          "sourceValidity": {
+            "direction": "COMPLETE"
+          },
+          "target": "Entry.444000777123.group%2E00%25.2"
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.001500129699707,
+                48.0,
+                0.10000002384185791
+              ],
+              [
+                11.001850128173828,
+                48.000179290771484,
+                0.10000002384185791
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.001899719238281,
+                48.00019836425781,
+                0.10000002384185791
+              ],
+              [
+                11.002050399780273,
+                48.00032043457031,
+                0.2999999523162842
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.1",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-001",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-1",
+                  "b-1"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.3",
+                "geometryName": "delta"
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-1",
+        "rank": 1,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.1
+        }
+      },
+      "recordId": 1,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.003000259399414,
+              48.0,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.0,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.0004997253418,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.0004997253418,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.0,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.2",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-002",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-2",
+                  "b-2"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-2",
+        "rank": 2,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.2
+        }
+      },
+      "recordId": 2,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.004500389099121,
+                48.0,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.00014877319336,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.000518798828125,
+                0.2999999523162842
+              ],
+              [
+                11.004500389099121,
+                48.0,
+                0.2999999523162842
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.004950523376465,
+                48.00014877319336,
+                0.2999999523162842
+              ],
+              [
+                11.005120277404785,
+                48.00054931640625,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.000518798828125,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.00014877319336,
+                0.2999999523162842
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.3",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-003",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-3",
+                  "b-3"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.004600524902344,
+                  48.000099182128906,
+                  0.30000001192092896
+                ]
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-3",
+        "rank": 3,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.3
+        }
+      },
+      "recordId": 3,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.4",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.004700660705566,
+              48.000099182128906,
+              0.30000001192092896
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.005999565124512,
+            48.0,
+            0.0
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.005999565124512,
+              48.0,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.0,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.00054999999702,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.00054999999702,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.0,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.4",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-004",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-4",
+                  "b-4"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.005999565124512,
+                      48.0,
+                      0.0
+                    ],
+                    [
+                      11.006239891052246,
+                      48.000179290771484,
+                      0.0
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-4",
+        "rank": 4,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.4
+        }
+      },
+      "recordId": 4,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 38074885079064,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.007499694824219,
+            48.0,
+            0.10000002384185791
+          ],
+          [
+            11.007780075073242,
+            48.0001106262207,
+            0.3999999761581421
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.5",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-005",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-5",
+                  "b-5"
+                ]
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-5",
+        "rank": 5,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.5
+        }
+      },
+      "recordId": 5,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 4629974745118,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.008999824523926,
+            48.0,
+            0.20000004768371582
+          ],
+          [
+            11.00944995880127,
+            48.000221252441406,
+            0.20000004768371582
+          ],
+          [
+            11.009900093078613,
+            48.00043869018555,
+            0.20000004768371582
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.6",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-006",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-6",
+                  "b-6"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.6",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.7",
+                "toConnectedEnd": "START",
+                "transitionNumber": 2
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-6",
+        "rank": 6,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.6
+        }
+      },
+      "recordId": 6,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 26963804684322,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.7",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.009200096130371,
+              48.000099182128906,
+              0.20000000298023224
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.010499954223633,
+                48.0,
+                0.2999999523162842
+              ],
+              [
+                11.010849952697754,
+                48.000179290771484,
+                0.2999999523162842
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.010899543762207,
+                48.00019836425781,
+                0.2999999523162842
+              ],
+              [
+                11.0110502243042,
+                48.00032043457031,
+                0.5
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.7",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-007",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-7",
+                  "b-7"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.9",
+                "geometryName": "delta"
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-0",
+        "rank": 7,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.7
+        }
+      },
+      "recordId": 7,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.01200008392334,
+              48.0,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.0,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.0004997253418,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.0004997253418,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.0,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.8",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-008",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-8",
+                  "b-8"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-1",
+        "rank": 8,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.8
+        }
+      },
+      "recordId": 8,
+      "relations": [
+        {
+          "name": "shadow",
+          "sourceValidity": {
+            "direction": "COMPLETE"
+          },
+          "target": "Entry.444000777123.group%2E00%25.10"
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.013500213623047,
+                48.0,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.00014877319336,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.000518798828125,
+                0.10000002384185791
+              ],
+              [
+                11.013500213623047,
+                48.0,
+                0.10000002384185791
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.01395034790039,
+                48.00014877319336,
+                0.10000002384185791
+              ],
+              [
+                11.014120101928711,
+                48.00054931640625,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.000518798828125,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.00014877319336,
+                0.10000002384185791
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.9",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-009",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-9",
+                  "b-9"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.01360034942627,
+                  48.000099182128906,
+                  0.10000000149011612
+                ]
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-2",
+        "rank": 9,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.0
+        }
+      },
+      "recordId": 9,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.10",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.013700485229492,
+              48.000099182128906,
+              0.10000000149011612
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 38354057953309,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.015000343322754,
+            48.0,
+            0.20000004768371582
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.015000343322754,
+              48.0,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.0,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.00054999999702,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.00054999999702,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.0,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.10",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-010",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-10",
+                  "b-10"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.015000343322754,
+                      48.0,
+                      0.20000004768371582
+                    ],
+                    [
+                      11.015240669250488,
+                      48.000179290771484,
+                      0.20000004768371582
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": null,
+        "rank": 10,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.1
+        }
+      },
+      "recordId": 10,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.016500473022461,
+            48.0,
+            0.2999999523162842
+          ],
+          [
+            11.016780853271484,
+            48.0001106262207,
+            0.6000000238418579
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.11",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-011",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-11",
+                  "b-11"
+                ]
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-4",
+        "rank": 11,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.2
+        }
+      },
+      "recordId": 11,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 4964982194201,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.0,
+            48.00120162963867,
+            0.0
+          ],
+          [
+            11.000450134277344,
+            48.00142288208008,
+            0.0
+          ],
+          [
+            11.000900268554688,
+            48.00164031982422,
+            0.0
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.12",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-012",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-12",
+                  "b-12"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.12",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.13",
+                "toConnectedEnd": "START",
+                "transitionNumber": 3
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-5",
+        "rank": 12,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.3
+        }
+      },
+      "recordId": 12,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 27298812133405,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.13",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.000200271606445,
+              48.00130081176758,
+              0.0
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.001500129699707,
+                48.00120162963867,
+                0.10000002384185791
+              ],
+              [
+                11.001850128173828,
+                48.001380920410156,
+                0.10000002384185791
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.001899719238281,
+                48.001399993896484,
+                0.10000002384185791
+              ],
+              [
+                11.002050399780273,
+                48.001522064208984,
+                0.2999999523162842
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.13",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-013",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-13",
+                  "b-13"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.15",
+                "geometryName": "delta"
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-6",
+        "rank": 13,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.4
+        }
+      },
+      "recordId": 13,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.003000259399414,
+              48.00120162963867,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.00120162963867,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.00170135498047,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.00170135498047,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.00120162963867,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.14",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-014",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-14",
+                  "b-14"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-0",
+        "rank": 14,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.5
+        }
+      },
+      "recordId": 14,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 38633230827554,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.004500389099121,
+                48.00120162963867,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.00135040283203,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.0017204284668,
+                0.2999999523162842
+              ],
+              [
+                11.004500389099121,
+                48.00120162963867,
+                0.2999999523162842
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.004950523376465,
+                48.00135040283203,
+                0.2999999523162842
+              ],
+              [
+                11.005120277404785,
+                48.00175094604492,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.0017204284668,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.00135040283203,
+                0.2999999523162842
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.15",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-015",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-15",
+                  "b-15"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.004600524902344,
+                  48.00130081176758,
+                  0.30000001192092896
+                ]
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-1",
+        "rank": 15,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.6
+        }
+      },
+      "recordId": 15,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.16",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.004700660705566,
+              48.00130081176758,
+              0.30000001192092896
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.005999565124512,
+            48.00120162963867,
+            0.0
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.005999565124512,
+              48.00120162963867,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.00120162963867,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.00175162963569,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.00175162963569,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.00120162963867,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.16",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-016",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-16",
+                  "b-16"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.005999565124512,
+                      48.00120162963867,
+                      0.0
+                    ],
+                    [
+                      11.006239891052246,
+                      48.001380920410156,
+                      0.0
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-2",
+        "rank": 16,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.7
+        }
+      },
+      "recordId": 16,
+      "relations": [
+        {
+          "name": "shadow",
+          "sourceValidity": {
+            "direction": "COMPLETE"
+          },
+          "target": "Entry.444000777123.group%2E00%25.18"
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.007499694824219,
+            48.00120162963867,
+            0.10000002384185791
+          ],
+          [
+            11.007780075073242,
+            48.001312255859375,
+            0.3999999761581421
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.17",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-017",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-17",
+                  "b-17"
+                ]
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-3",
+        "rank": 0,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.8
+        }
+      },
+      "recordId": 17,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 5299989643295,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.008999824523926,
+            48.00120162963867,
+            0.20000004768371582
+          ],
+          [
+            11.00944995880127,
+            48.00142288208008,
+            0.20000004768371582
+          ],
+          [
+            11.009900093078613,
+            48.00164031982422,
+            0.20000004768371582
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.18",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-018",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-18",
+                  "b-18"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.18",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.19",
+                "toConnectedEnd": "START",
+                "transitionNumber": 4
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-4",
+        "rank": 1,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.0
+        }
+      },
+      "recordId": 18,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 27633819582488,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.19",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.009200096130371,
+              48.00130081176758,
+              0.20000000298023224
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.010499954223633,
+                48.00120162963867,
+                0.2999999523162842
+              ],
+              [
+                11.010849952697754,
+                48.001380920410156,
+                0.2999999523162842
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.010899543762207,
+                48.001399993896484,
+                0.2999999523162842
+              ],
+              [
+                11.0110502243042,
+                48.001522064208984,
+                0.5
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.19",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-019",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-19",
+                  "b-19"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.21",
+                "geometryName": "delta"
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-5",
+        "rank": 2,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.1
+        }
+      },
+      "recordId": 19,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 38912403701788,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.01200008392334,
+              48.00120162963867,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.00120162963867,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.00170135498047,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.00170135498047,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.00120162963867,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.20",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-020",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-20",
+                  "b-20"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": null,
+        "rank": 3,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.2
+        }
+      },
+      "recordId": 20,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.013500213623047,
+                48.00120162963867,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.00135040283203,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.0017204284668,
+                0.10000002384185791
+              ],
+              [
+                11.013500213623047,
+                48.00120162963867,
+                0.10000002384185791
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.01395034790039,
+                48.00135040283203,
+                0.10000002384185791
+              ],
+              [
+                11.014120101928711,
+                48.00175094604492,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.0017204284668,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.00135040283203,
+                0.10000002384185791
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.21",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-021",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-21",
+                  "b-21"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.01360034942627,
+                  48.00130081176758,
+                  0.10000000149011612
+                ]
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-0",
+        "rank": 4,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.3
+        }
+      },
+      "recordId": 21,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.22",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.013700485229492,
+              48.00130081176758,
+              0.10000000149011612
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.015000343322754,
+            48.00120162963867,
+            0.20000004768371582
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.015000343322754,
+              48.00120162963867,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.00120162963867,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.00175162963569,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.00175162963569,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.00120162963867,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.22",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-022",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-22",
+                  "b-22"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.015000343322754,
+                      48.00120162963867,
+                      0.20000004768371582
+                    ],
+                    [
+                      11.015240669250488,
+                      48.001380920410156,
+                      0.20000004768371582
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-1",
+        "rank": 5,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.4
+        }
+      },
+      "recordId": 22,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.016500473022461,
+            48.00120162963867,
+            0.2999999523162842
+          ],
+          [
+            11.016780853271484,
+            48.001312255859375,
+            0.6000000238418579
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.23",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-023",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-23",
+                  "b-23"
+                ]
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-2",
+        "rank": 6,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.5
+        }
+      },
+      "recordId": 23,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 5634997092378,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.0,
+            48.00239944458008,
+            0.0
+          ],
+          [
+            11.000450134277344,
+            48.002620697021484,
+            0.0
+          ],
+          [
+            11.000900268554688,
+            48.002838134765625,
+            0.0
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.24",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-024",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-24",
+                  "b-24"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.24",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.25",
+                "toConnectedEnd": "START",
+                "transitionNumber": 5
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-3",
+        "rank": 7,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.6
+        }
+      },
+      "recordId": 24,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 27968827031582,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.25",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.000200271606445,
+              48.002498626708984,
+              0.0
+            ]
+          }
+        },
+        {
+          "name": "shadow",
+          "sourceValidity": {
+            "direction": "COMPLETE"
+          },
+          "target": "Entry.444000777123.group%2E00%25.26"
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 39191576576033,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.001500129699707,
+                48.00239944458008,
+                0.10000002384185791
+              ],
+              [
+                11.001850128173828,
+                48.00257873535156,
+                0.10000002384185791
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.001899719238281,
+                48.00259780883789,
+                0.10000002384185791
+              ],
+              [
+                11.002050399780273,
+                48.00271987915039,
+                0.2999999523162842
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.25",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-025",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-25",
+                  "b-25"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.27",
+                "geometryName": "delta"
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-4",
+        "rank": 8,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.7
+        }
+      },
+      "recordId": 25,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.003000259399414,
+              48.00239944458008,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.00239944458008,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.002899169921875,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.002899169921875,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.00239944458008,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.26",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-026",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-26",
+                  "b-26"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-5",
+        "rank": 9,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.8
+        }
+      },
+      "recordId": 26,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.004500389099121,
+                48.00239944458008,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.00254821777344,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.0029182434082,
+                0.2999999523162842
+              ],
+              [
+                11.004500389099121,
+                48.00239944458008,
+                0.2999999523162842
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.004950523376465,
+                48.00254821777344,
+                0.2999999523162842
+              ],
+              [
+                11.005120277404785,
+                48.00294876098633,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.0029182434082,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.00254821777344,
+                0.2999999523162842
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.27",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-027",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-27",
+                  "b-27"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.004600524902344,
+                  48.002498626708984,
+                  0.30000001192092896
+                ]
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-6",
+        "rank": 10,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.0
+        }
+      },
+      "recordId": 27,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.28",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.004700660705566,
+              48.002498626708984,
+              0.30000001192092896
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.005999565124512,
+            48.00239944458008,
+            0.0
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.005999565124512,
+              48.00239944458008,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.00239944458008,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.0029494445771,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.0029494445771,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.00239944458008,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.28",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-028",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-28",
+                  "b-28"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.005999565124512,
+                      48.00239944458008,
+                      0.0
+                    ],
+                    [
+                      11.006239891052246,
+                      48.00257873535156,
+                      0.0
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-0",
+        "rank": 11,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.1
+        }
+      },
+      "recordId": 28,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.007499694824219,
+            48.00239944458008,
+            0.10000002384185791
+          ],
+          [
+            11.007780075073242,
+            48.00251007080078,
+            0.3999999761581421
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.29",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-029",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-29",
+                  "b-29"
+                ]
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-1",
+        "rank": 12,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.2
+        }
+      },
+      "recordId": 29,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 39470749450267,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 5970004541472,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.008999824523926,
+            48.00239944458008,
+            0.20000004768371582
+          ],
+          [
+            11.00944995880127,
+            48.002620697021484,
+            0.20000004768371582
+          ],
+          [
+            11.009900093078613,
+            48.002838134765625,
+            0.20000004768371582
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.30",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-030",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-30",
+                  "b-30"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.30",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.31",
+                "toConnectedEnd": "START",
+                "transitionNumber": 6
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": null,
+        "rank": 13,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.3
+        }
+      },
+      "recordId": 30,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 28303834480665,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.31",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.009200096130371,
+              48.002498626708984,
+              0.20000000298023224
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.010499954223633,
+                48.00239944458008,
+                0.2999999523162842
+              ],
+              [
+                11.010849952697754,
+                48.00257873535156,
+                0.2999999523162842
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.010899543762207,
+                48.00259780883789,
+                0.2999999523162842
+              ],
+              [
+                11.0110502243042,
+                48.00271987915039,
+                0.5
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.31",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-031",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-31",
+                  "b-31"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.33",
+                "geometryName": "delta"
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-3",
+        "rank": 14,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.4
+        }
+      },
+      "recordId": 31,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.01200008392334,
+              48.00239944458008,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.00239944458008,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.002899169921875,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.002899169921875,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.00239944458008,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.32",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-032",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-32",
+                  "b-32"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-4",
+        "rank": 15,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.5
+        }
+      },
+      "recordId": 32,
+      "relations": [
+        {
+          "name": "shadow",
+          "sourceValidity": {
+            "direction": "COMPLETE"
+          },
+          "target": "Entry.444000777123.group%2E00%25.34"
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.013500213623047,
+                48.00239944458008,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.00254821777344,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.0029182434082,
+                0.10000002384185791
+              ],
+              [
+                11.013500213623047,
+                48.00239944458008,
+                0.10000002384185791
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.01395034790039,
+                48.00254821777344,
+                0.10000002384185791
+              ],
+              [
+                11.014120101928711,
+                48.00294876098633,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.0029182434082,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.00254821777344,
+                0.10000002384185791
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.33",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-033",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-33",
+                  "b-33"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.01360034942627,
+                  48.002498626708984,
+                  0.10000000149011612
+                ]
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-5",
+        "rank": 16,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.6
+        }
+      },
+      "recordId": 33,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.34",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.013700485229492,
+              48.002498626708984,
+              0.10000000149011612
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.015000343322754,
+            48.00239944458008,
+            0.20000004768371582
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.015000343322754,
+              48.00239944458008,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.00239944458008,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.0029494445771,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.0029494445771,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.00239944458008,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.34",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-034",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-34",
+                  "b-34"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.015000343322754,
+                      48.00239944458008,
+                      0.20000004768371582
+                    ],
+                    [
+                      11.015240669250488,
+                      48.00257873535156,
+                      0.20000004768371582
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-6",
+        "rank": 0,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.7
+        }
+      },
+      "recordId": 34,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 39749922324512,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.016500473022461,
+            48.00239944458008,
+            0.2999999523162842
+          ],
+          [
+            11.016780853271484,
+            48.00251007080078,
+            0.6000000238418579
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.35",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-035",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-35",
+                  "b-35"
+                ]
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-0",
+        "rank": 1,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.8
+        }
+      },
+      "recordId": 35,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 6305011990555,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.0,
+            48.00360107421875,
+            0.0
+          ],
+          [
+            11.000450134277344,
+            48.003822326660156,
+            0.0
+          ],
+          [
+            11.000900268554688,
+            48.0040397644043,
+            0.0
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.36",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-036",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-36",
+                  "b-36"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.36",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.37",
+                "toConnectedEnd": "START",
+                "transitionNumber": 7
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-1",
+        "rank": 2,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.0
+        }
+      },
+      "recordId": 36,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 28638841929759,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.37",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.000200271606445,
+              48.003700256347656,
+              0.0
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.001500129699707,
+                48.00360107421875,
+                0.10000002384185791
+              ],
+              [
+                11.001850128173828,
+                48.003780364990234,
+                0.10000002384185791
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.001899719238281,
+                48.00379943847656,
+                0.10000002384185791
+              ],
+              [
+                11.002050399780273,
+                48.00392150878906,
+                0.2999999523162842
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.37",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-037",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-37",
+                  "b-37"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.39",
+                "geometryName": "delta"
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-2",
+        "rank": 3,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.1
+        }
+      },
+      "recordId": 37,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.003000259399414,
+              48.00360107421875,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.00360107421875,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.00410079956055,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.00410079956055,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.00360107421875,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.38",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-038",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-38",
+                  "b-38"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-3",
+        "rank": 4,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.2
+        }
+      },
+      "recordId": 38,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.004500389099121,
+                48.00360107421875,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.00374984741211,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.004119873046875,
+                0.2999999523162842
+              ],
+              [
+                11.004500389099121,
+                48.00360107421875,
+                0.2999999523162842
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.004950523376465,
+                48.00374984741211,
+                0.2999999523162842
+              ],
+              [
+                11.005120277404785,
+                48.004150390625,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.004119873046875,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.00374984741211,
+                0.2999999523162842
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.39",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-039",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-39",
+                  "b-39"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.004600524902344,
+                  48.003700256347656,
+                  0.30000001192092896
+                ]
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-4",
+        "rank": 5,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.3
+        }
+      },
+      "recordId": 39,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.40",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.004700660705566,
+              48.003700256347656,
+              0.30000001192092896
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 40029095198746,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.005999565124512,
+            48.00360107421875,
+            0.0
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.005999565124512,
+              48.00360107421875,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.00360107421875,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.00415107421577,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.00415107421577,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.00360107421875,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.40",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-040",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-40",
+                  "b-40"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.005999565124512,
+                      48.00360107421875,
+                      0.0
+                    ],
+                    [
+                      11.006239891052246,
+                      48.003780364990234,
+                      0.0
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": null,
+        "rank": 6,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.4
+        }
+      },
+      "recordId": 40,
+      "relations": [
+        {
+          "name": "shadow",
+          "sourceValidity": {
+            "direction": "COMPLETE"
+          },
+          "target": "Entry.444000777123.group%2E00%25.42"
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.007499694824219,
+            48.00360107421875,
+            0.10000002384185791
+          ],
+          [
+            11.007780075073242,
+            48.00371170043945,
+            0.3999999761581421
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.41",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-041",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-41",
+                  "b-41"
+                ]
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-6",
+        "rank": 7,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.5
+        }
+      },
+      "recordId": 41,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 6640019439649,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.008999824523926,
+            48.00360107421875,
+            0.20000004768371582
+          ],
+          [
+            11.00944995880127,
+            48.003822326660156,
+            0.20000004768371582
+          ],
+          [
+            11.009900093078613,
+            48.0040397644043,
+            0.20000004768371582
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.42",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-042",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-42",
+                  "b-42"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.42",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.43",
+                "toConnectedEnd": "START",
+                "transitionNumber": 8
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-0",
+        "rank": 8,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.6
+        }
+      },
+      "recordId": 42,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 28973849378842,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.43",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.009200096130371,
+              48.003700256347656,
+              0.20000000298023224
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.010499954223633,
+                48.00360107421875,
+                0.2999999523162842
+              ],
+              [
+                11.010849952697754,
+                48.003780364990234,
+                0.2999999523162842
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.010899543762207,
+                48.00379943847656,
+                0.2999999523162842
+              ],
+              [
+                11.0110502243042,
+                48.00392150878906,
+                0.5
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.43",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-043",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-43",
+                  "b-43"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.45",
+                "geometryName": "delta"
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-1",
+        "rank": 9,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.7
+        }
+      },
+      "recordId": 43,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.01200008392334,
+              48.00360107421875,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.00360107421875,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.00410079956055,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.00410079956055,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.00360107421875,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.44",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-044",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-44",
+                  "b-44"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-2",
+        "rank": 10,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.8
+        }
+      },
+      "recordId": 44,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 40308268072991,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.013500213623047,
+                48.00360107421875,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.00374984741211,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.004119873046875,
+                0.10000002384185791
+              ],
+              [
+                11.013500213623047,
+                48.00360107421875,
+                0.10000002384185791
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.01395034790039,
+                48.00374984741211,
+                0.10000002384185791
+              ],
+              [
+                11.014120101928711,
+                48.004150390625,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.004119873046875,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.00374984741211,
+                0.10000002384185791
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.45",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-045",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-45",
+                  "b-45"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.01360034942627,
+                  48.003700256347656,
+                  0.10000000149011612
+                ]
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-3",
+        "rank": 11,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.0
+        }
+      },
+      "recordId": 45,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.46",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.013700485229492,
+              48.003700256347656,
+              0.10000000149011612
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.015000343322754,
+            48.00360107421875,
+            0.20000004768371582
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.015000343322754,
+              48.00360107421875,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.00360107421875,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.00415107421577,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.00415107421577,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.00360107421875,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.46",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-046",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-46",
+                  "b-46"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.015000343322754,
+                      48.00360107421875,
+                      0.20000004768371582
+                    ],
+                    [
+                      11.015240669250488,
+                      48.003780364990234,
+                      0.20000004768371582
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-4",
+        "rank": 12,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.1
+        }
+      },
+      "recordId": 46,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.016500473022461,
+            48.00360107421875,
+            0.2999999523162842
+          ],
+          [
+            11.016780853271484,
+            48.00371170043945,
+            0.6000000238418579
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.47",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-047",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-47",
+                  "b-47"
+                ]
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-5",
+        "rank": 13,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.2
+        }
+      },
+      "recordId": 47,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 6975026888732,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.0,
+            48.004798889160156,
+            0.0
+          ],
+          [
+            11.000450134277344,
+            48.00502014160156,
+            0.0
+          ],
+          [
+            11.000900268554688,
+            48.0052375793457,
+            0.0
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.48",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-048",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-48",
+                  "b-48"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.48",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.49",
+                "toConnectedEnd": "START",
+                "transitionNumber": 9
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-6",
+        "rank": 14,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.3
+        }
+      },
+      "recordId": 48,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 29308856827936,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.49",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.000200271606445,
+              48.00489807128906,
+              0.0
+            ]
+          }
+        },
+        {
+          "name": "shadow",
+          "sourceValidity": {
+            "direction": "COMPLETE"
+          },
+          "target": "Entry.444000777123.group%2E00%25.50"
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.001500129699707,
+                48.004798889160156,
+                0.10000002384185791
+              ],
+              [
+                11.001850128173828,
+                48.00497817993164,
+                0.10000002384185791
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.001899719238281,
+                48.00499725341797,
+                0.10000002384185791
+              ],
+              [
+                11.002050399780273,
+                48.00511932373047,
+                0.2999999523162842
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.49",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-049",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-49",
+                  "b-49"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.51",
+                "geometryName": "delta"
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-0",
+        "rank": 15,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.4
+        }
+      },
+      "recordId": 49,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 40587440947225,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.003000259399414,
+              48.004798889160156,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.004798889160156,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.00529861450195,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.00529861450195,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.004798889160156,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.50",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-050",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-50",
+                  "b-50"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": null,
+        "rank": 16,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.5
+        }
+      },
+      "recordId": 50,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.004500389099121,
+                48.004798889160156,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.004947662353516,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.00531768798828,
+                0.2999999523162842
+              ],
+              [
+                11.004500389099121,
+                48.004798889160156,
+                0.2999999523162842
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.004950523376465,
+                48.004947662353516,
+                0.2999999523162842
+              ],
+              [
+                11.005120277404785,
+                48.005348205566406,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.00531768798828,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.004947662353516,
+                0.2999999523162842
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.51",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-051",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-51",
+                  "b-51"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.004600524902344,
+                  48.00489807128906,
+                  0.30000001192092896
+                ]
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-2",
+        "rank": 0,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.6
+        }
+      },
+      "recordId": 51,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.52",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.004700660705566,
+              48.00489807128906,
+              0.30000001192092896
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.005999565124512,
+            48.004798889160156,
+            0.0
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.005999565124512,
+              48.004798889160156,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.004798889160156,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.005348889157176,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.005348889157176,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.004798889160156,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.52",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-052",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-52",
+                  "b-52"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.005999565124512,
+                      48.004798889160156,
+                      0.0
+                    ],
+                    [
+                      11.006239891052246,
+                      48.00497817993164,
+                      0.0
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-3",
+        "rank": 1,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.7
+        }
+      },
+      "recordId": 52,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.007499694824219,
+            48.004798889160156,
+            0.10000002384185791
+          ],
+          [
+            11.007780075073242,
+            48.00490951538086,
+            0.3999999761581421
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.53",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-053",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-53",
+                  "b-53"
+                ]
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-4",
+        "rank": 2,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.8
+        }
+      },
+      "recordId": 53,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 7310034337826,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.008999824523926,
+            48.004798889160156,
+            0.20000004768371582
+          ],
+          [
+            11.00944995880127,
+            48.00502014160156,
+            0.20000004768371582
+          ],
+          [
+            11.009900093078613,
+            48.0052375793457,
+            0.20000004768371582
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.54",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-054",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-54",
+                  "b-54"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.54",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.55",
+                "toConnectedEnd": "START",
+                "transitionNumber": 10
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-5",
+        "rank": 3,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.0
+        }
+      },
+      "recordId": 54,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 29643864277019,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.55",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.009200096130371,
+              48.00489807128906,
+              0.20000000298023224
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 40866613821470,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.010499954223633,
+                48.004798889160156,
+                0.2999999523162842
+              ],
+              [
+                11.010849952697754,
+                48.00497817993164,
+                0.2999999523162842
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.010899543762207,
+                48.00499725341797,
+                0.2999999523162842
+              ],
+              [
+                11.0110502243042,
+                48.00511932373047,
+                0.5
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.55",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-055",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-55",
+                  "b-55"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.57",
+                "geometryName": "delta"
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-6",
+        "rank": 4,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.1
+        }
+      },
+      "recordId": 55,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.01200008392334,
+              48.004798889160156,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.004798889160156,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.00529861450195,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.00529861450195,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.004798889160156,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.56",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-056",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-56",
+                  "b-56"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-0",
+        "rank": 5,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.2
+        }
+      },
+      "recordId": 56,
+      "relations": [
+        {
+          "name": "shadow",
+          "sourceValidity": {
+            "direction": "COMPLETE"
+          },
+          "target": "Entry.444000777123.group%2E00%25.58"
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.013500213623047,
+                48.004798889160156,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.004947662353516,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.00531768798828,
+                0.10000002384185791
+              ],
+              [
+                11.013500213623047,
+                48.004798889160156,
+                0.10000002384185791
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.01395034790039,
+                48.004947662353516,
+                0.10000002384185791
+              ],
+              [
+                11.014120101928711,
+                48.005348205566406,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.00531768798828,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.004947662353516,
+                0.10000002384185791
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.57",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-057",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-57",
+                  "b-57"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.01360034942627,
+                  48.00489807128906,
+                  0.10000000149011612
+                ]
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-1",
+        "rank": 6,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.3
+        }
+      },
+      "recordId": 57,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.58",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.013700485229492,
+              48.00489807128906,
+              0.10000000149011612
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.015000343322754,
+            48.004798889160156,
+            0.20000004768371582
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.015000343322754,
+              48.004798889160156,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.004798889160156,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.005348889157176,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.005348889157176,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.004798889160156,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.58",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-058",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-58",
+                  "b-58"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.015000343322754,
+                      48.004798889160156,
+                      0.20000004768371582
+                    ],
+                    [
+                      11.015240669250488,
+                      48.00497817993164,
+                      0.20000004768371582
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-2",
+        "rank": 7,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.4
+        }
+      },
+      "recordId": 58,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.016500473022461,
+            48.004798889160156,
+            0.2999999523162842
+          ],
+          [
+            11.016780853271484,
+            48.00490951538086,
+            0.6000000238418579
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.59",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-059",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-59",
+                  "b-59"
+                ]
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-3",
+        "rank": 8,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.5
+        }
+      },
+      "recordId": 59,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 41145786695704,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 7645041786909,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.0,
+            48.00600051879883,
+            0.0
+          ],
+          [
+            11.000450134277344,
+            48.006221771240234,
+            0.0
+          ],
+          [
+            11.000900268554688,
+            48.006439208984375,
+            0.0
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.60",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-060",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-60",
+                  "b-60"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.60",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.61",
+                "toConnectedEnd": "START",
+                "transitionNumber": 11
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": null,
+        "rank": 9,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.6
+        }
+      },
+      "recordId": 60,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 29978871726113,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.61",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.000200271606445,
+              48.006099700927734,
+              0.0
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.001500129699707,
+                48.00600051879883,
+                0.10000002384185791
+              ],
+              [
+                11.001850128173828,
+                48.00617980957031,
+                0.10000002384185791
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.001899719238281,
+                48.00619888305664,
+                0.10000002384185791
+              ],
+              [
+                11.002050399780273,
+                48.00632095336914,
+                0.2999999523162842
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.61",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-061",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-61",
+                  "b-61"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.63",
+                "geometryName": "delta"
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-5",
+        "rank": 10,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.7
+        }
+      },
+      "recordId": 61,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.003000259399414,
+              48.00600051879883,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.00600051879883,
+              0.20000004768371582
+            ],
+            [
+              11.003650665283203,
+              48.006500244140625,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.006500244140625,
+              0.20000004768371582
+            ],
+            [
+              11.003000259399414,
+              48.00600051879883,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.62",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-062",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-62",
+                  "b-62"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-6",
+        "rank": 11,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.8
+        }
+      },
+      "recordId": 62,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.004500389099121,
+                48.00600051879883,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.00614929199219,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.00651931762695,
+                0.2999999523162842
+              ],
+              [
+                11.004500389099121,
+                48.00600051879883,
+                0.2999999523162842
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.004950523376465,
+                48.00614929199219,
+                0.2999999523162842
+              ],
+              [
+                11.005120277404785,
+                48.00654983520508,
+                0.2999999523162842
+              ],
+              [
+                11.004650115966797,
+                48.00651931762695,
+                0.2999999523162842
+              ],
+              [
+                11.004950523376465,
+                48.00614929199219,
+                0.2999999523162842
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.63",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-063",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-63",
+                  "b-63"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.004600524902344,
+                  48.006099700927734,
+                  0.30000001192092896
+                ]
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-0",
+        "rank": 12,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.0
+        }
+      },
+      "recordId": 63,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.64",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.004700660705566,
+              48.006099700927734,
+              0.30000001192092896
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.005999565124512,
+            48.00600051879883,
+            0.0
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.005999565124512,
+              48.00600051879883,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.00600051879883,
+              0.0
+            ],
+            [
+              11.006699565099552,
+              48.00655051879585,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.00655051879585,
+              0.0
+            ],
+            [
+              11.005999565124512,
+              48.00600051879883,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.64",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-064",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-64",
+                  "b-64"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.005999565124512,
+                      48.00600051879883,
+                      0.0
+                    ],
+                    [
+                      11.006239891052246,
+                      48.00617980957031,
+                      0.0
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-1",
+        "rank": 13,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.1
+        }
+      },
+      "recordId": 64,
+      "relations": [
+        {
+          "name": "shadow",
+          "sourceValidity": {
+            "direction": "COMPLETE"
+          },
+          "target": "Entry.444000777123.group%2E00%25.66"
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 41424959569949,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.007499694824219,
+            48.00600051879883,
+            0.10000002384185791
+          ],
+          [
+            11.007780075073242,
+            48.00611114501953,
+            0.3999999761581421
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.65",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-065",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-65",
+                  "b-65"
+                ]
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-2",
+        "rank": 14,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.2
+        }
+      },
+      "recordId": 65,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "_sourceData": [
+          {
+            "address": 7980049235992,
+            "layerId": "src-set",
+            "qualifier": "geom-main"
+          }
+        ],
+        "coordinates": [
+          [
+            11.008999824523926,
+            48.00600051879883,
+            0.20000004768371582
+          ],
+          [
+            11.00944995880127,
+            48.006221771240234,
+            0.20000004768371582
+          ],
+          [
+            11.009900093078613,
+            48.006439208984375,
+            0.20000004768371582
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "LineString"
+      },
+      "id": "Entry.444000777123.group%2E00%25.66",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-066",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-66",
+                  "b-66"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "from": "Entry.444000777123.group%2E00%25.66",
+                "fromConnectedEnd": "END",
+                "to": "Entry.444000777123.group%2E00%25.67",
+                "toConnectedEnd": "START",
+                "transitionNumber": 12
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-3",
+        "rank": 15,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.3
+        }
+      },
+      "recordId": 66,
+      "relations": [
+        {
+          "_sourceData": [
+            {
+              "address": 30313879175196,
+              "layerId": "src-set",
+              "qualifier": "rel-main"
+            }
+          ],
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.67",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.009200096130371,
+              48.006099700927734,
+              0.20000000298023224
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "geometries": [
+          {
+            "coordinates": [
+              [
+                11.010499954223633,
+                48.00600051879883,
+                0.2999999523162842
+              ],
+              [
+                11.010849952697754,
+                48.00617980957031,
+                0.2999999523162842
+              ]
+            ],
+            "type": "LineString"
+          },
+          {
+            "coordinates": [
+              [
+                11.010899543762207,
+                48.00619888305664,
+                0.2999999523162842
+              ],
+              [
+                11.0110502243042,
+                48.00632095336914,
+                0.5
+              ]
+            ],
+            "type": "MultiPoint"
+          }
+        ],
+        "type": "GeometryCollection"
+      },
+      "id": "Entry.444000777123.group%2E00%25.67",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-067",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-67",
+                  "b-67"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "featureId": "Entry.444000777123.group%2E00%25.69",
+                "geometryName": "delta"
+              },
+              "value": "token-2"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-4",
+        "rank": 16,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.4
+        }
+      },
+      "recordId": 67,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              11.01200008392334,
+              48.00600051879883,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.00600051879883,
+              0.0
+            ],
+            [
+              11.012650489807129,
+              48.006500244140625,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.006500244140625,
+              0.0
+            ],
+            [
+              11.01200008392334,
+              48.00600051879883,
+              0.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.68",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-068",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-68",
+                  "b-68"
+                ]
+              },
+              "validity": {
+                "direction": "POSITIVE",
+                "end": 0.8,
+                "geometryName": "delta",
+                "offsetType": "RelativeLengthOffset",
+                "start": 0.1
+              },
+              "value": "token-3"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": "note-5",
+        "rank": 0,
+        "summary": {
+          "kind": "kind-0",
+          "score": 0.5
+        }
+      },
+      "recordId": 68,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              [
+                11.013500213623047,
+                48.00600051879883,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.00614929199219,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.00651931762695,
+                0.10000002384185791
+              ],
+              [
+                11.013500213623047,
+                48.00600051879883,
+                0.10000002384185791
+              ]
+            ]
+          ],
+          [
+            [
+              [
+                11.01395034790039,
+                48.00614929199219,
+                0.10000002384185791
+              ],
+              [
+                11.014120101928711,
+                48.00654983520508,
+                0.10000002384185791
+              ],
+              [
+                11.013649940490723,
+                48.00651931762695,
+                0.10000002384185791
+              ],
+              [
+                11.01395034790039,
+                48.00614929199219,
+                0.10000002384185791
+              ]
+            ]
+          ]
+        ],
+        "geometryName": "delta",
+        "type": "MultiPolygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.69",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-069",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-69",
+                  "b-69"
+                ]
+              },
+              "validity": {
+                "direction": "NEGATIVE",
+                "offsetType": "GeoPosOffset",
+                "point": [
+                  11.01360034942627,
+                  48.006099700927734,
+                  0.10000000149011612
+                ]
+              },
+              "value": "token-4"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": true,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-6",
+        "rank": 1,
+        "summary": {
+          "kind": "kind-1",
+          "score": 0.6
+        }
+      },
+      "recordId": 69,
+      "relations": [
+        {
+          "name": "peer",
+          "sourceValidity": {
+            "direction": "POSITIVE",
+            "end": 0.7,
+            "geometryName": "delta",
+            "offsetType": "RelativeLengthOffset",
+            "start": 0.2
+          },
+          "target": "Entry.444000777123.group%2E00%25.70",
+          "targetValidity": {
+            "direction": "NEGATIVE",
+            "offsetType": "GeoPosOffset",
+            "point": [
+              11.013700485229492,
+              48.006099700927734,
+              0.10000000149011612
+            ]
+          }
+        }
+      ],
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "_sourceData": [
+        {
+          "address": 41704132444194,
+          "layerId": "src-set",
+          "qualifier": "feature-main"
+        }
+      ],
+      "bucketId": "group.00%",
+      "geometry": {
+        "aabb": {
+          "origin": [
+            11.015000343322754,
+            48.00600051879883,
+            0.20000004768371582
+          ],
+          "size": [
+            0.000699999975040555,
+            0.0005499999970197678,
+            0.20000000298023224
+          ]
+        },
+        "coordinates": [
+          [
+            [
+              11.015000343322754,
+              48.00600051879883,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.00600051879883,
+              0.20000004768371582
+            ],
+            [
+              11.015700343297794,
+              48.00655051879585,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.00655051879585,
+              0.20000004768371582
+            ],
+            [
+              11.015000343322754,
+              48.00600051879883,
+              0.20000004768371582
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "id": "Entry.444000777123.group%2E00%25.70",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": true,
+        "label": "item-070",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-70",
+                  "b-70"
+                ]
+              },
+              "validity": {
+                "direction": "COMPLETE",
+                "geometry": {
+                  "coordinates": [
+                    [
+                      11.015000343322754,
+                      48.00600051879883,
+                      0.20000004768371582
+                    ],
+                    [
+                      11.015240669250488,
+                      48.00617980957031,
+                      0.20000004768371582
+                    ]
+                  ],
+                  "geometryName": "delta",
+                  "type": "LineString"
+                }
+              },
+              "value": "token-0"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "warm"
+            }
+          }
+        },
+        "notes": null,
+        "rank": 2,
+        "summary": {
+          "kind": "kind-2",
+          "score": 0.7
+        }
+      },
+      "recordId": 70,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    },
+    {
+      "bucketId": "group.00%",
+      "geometry": {
+        "coordinates": [
+          [
+            11.016500473022461,
+            48.00600051879883,
+            0.2999999523162842
+          ],
+          [
+            11.016780853271484,
+            48.00611114501953,
+            0.6000000238418579
+          ]
+        ],
+        "type": "MultiPoint"
+      },
+      "id": "Entry.444000777123.group%2E00%25.71",
+      "layerId": "CollectionLayer",
+      "mapId": "DatasetAlpha",
+      "properties": {
+        "active": false,
+        "label": "item-071",
+        "layer": {
+          "bundle": {
+            "slotMain": {
+              "meta": {
+                "_multimap": true,
+                "blob": [
+                  {
+                    "_bytes": true,
+                    "hex": "4142",
+                    "number": 16706
+                  }
+                ],
+                "tag": [
+                  "a-71",
+                  "b-71"
+                ]
+              },
+              "value": "token-1"
+            }
+          },
+          "status": {
+            "slotAux": {
+              "flag": false,
+              "state": "cold"
+            }
+          }
+        },
+        "notes": "note-1",
+        "rank": 3,
+        "summary": {
+          "kind": "kind-3",
+          "score": 0.8
+        }
+      },
+      "recordId": 71,
+      "tileId": 444000777123,
+      "type": "Feature",
+      "typeId": "Entry"
+    }
+  ],
+  "geometryAnchor": [
+    11.125,
+    48.125,
+    2.0
+  ],
+  "mapId": "DatasetAlpha",
+  "mapgetLayerId": "CollectionLayer",
+  "mapgetTileId": 444000777123,
+  "timestamp": "2024-06-01T12:34:56.123456Z",
+  "ttl": 60000,
+  "type": "FeatureCollection"
+}

--- a/test/unit/data/large-geojson-featureset.feature-collection.json
+++ b/test/unit/data/large-geojson-featureset.feature-collection.json
@@ -7257,7 +7257,7 @@
   "mapId": "DatasetAlpha",
   "mapgetLayerId": "CollectionLayer",
   "mapgetTileId": 444000777123,
-  "timestamp": "2024-06-01T12:34:56.123456Z",
+  "timestamp": 1717245296123456,
   "ttl": 60000,
   "type": "FeatureCollection"
 }

--- a/test/unit/data/large-geojson-featureset.layer-info.json
+++ b/test/unit/data/large-geojson-featureset.layer-info.json
@@ -1,0 +1,33 @@
+{
+  "layerId": "CollectionLayer",
+  "type": "Features",
+  "featureTypes": [
+    {
+      "name": "Entry",
+      "uniqueIdCompositions": [
+        [
+          {
+            "partId": "tileId",
+            "datatype": "U64",
+            "isSynthetic": true
+          },
+          {
+            "partId": "bucketId",
+            "datatype": "STR"
+          },
+          {
+            "partId": "recordId",
+            "datatype": "U32"
+          }
+        ]
+      ]
+    }
+  ],
+  "stages": 3,
+  "stageLabels": [
+    "draft",
+    "full",
+    "delta"
+  ],
+  "highFidelityStage": 1
+}

--- a/test/unit/test-geojson-import.cpp
+++ b/test/unit/test-geojson-import.cpp
@@ -219,6 +219,18 @@ TEST_CASE("TileFeatureLayer strict GeoJSON import roundtrips mapget JSON", "[Geo
         3,
         Validity::Positive);
 
+    auto externalRoadReference = tile->newFeatureId(
+        "Road",
+        {
+            {"tileId", static_cast<int64_t>(77)},
+            {"regionId", "DE.BY%"},
+            {"roadId", 11},
+        },
+        "ValidationMap");
+    auto clearance = restrictions->newAttribute("clearance");
+    requireExpectedOk(clearance->addField("value", double{3.5}));
+    clearance->validity()->newFeatureId(externalRoadReference, Validity::Negative);
+
     auto relation = tile->newRelation(
         "connectedTo",
         tile->newFeatureId(
@@ -227,7 +239,8 @@ TEST_CASE("TileFeatureLayer strict GeoJSON import roundtrips mapget JSON", "[Geo
                 {"tileId", static_cast<int64_t>(77)},
                 {"regionId", "DE.BY%"},
                 {"roadId", 9},
-            }));
+            },
+            "ValidationMap"));
     relation->setSourceDataReferences(makeSourceDataRefs(
         *tile,
         {{70, 8, "rules-src", "relation"}}));
@@ -250,6 +263,16 @@ TEST_CASE("TileFeatureLayer strict GeoJSON import roundtrips mapget JSON", "[Geo
     auto originalJson = tile->toJson();
     REQUIRE(originalJson["features"][0]["id"] == "Road.77.DE%2EBY%25.7");
     REQUIRE(originalJson["features"][0]["geometry"]["type"] == "GeometryCollection");
+    REQUIRE(originalJson["features"][0]["relations"][0]["target"] == nlohmann::json{
+        {"id", "Road.77.DE%2EBY%25.9"},
+        {"mapId", "ValidationMap"},
+    });
+    REQUIRE(
+        originalJson["features"][0]["properties"]["layer"]["restrictions"]["clearance"]["validity"]["featureId"] ==
+        nlohmann::json{
+            {"id", "Road.77.DE%2EBY%25.11"},
+            {"mapId", "ValidationMap"},
+        });
 
     auto imported = makeTile(77, layerInfo, "StrictImportNode", "StrictImportMap");
     REQUIRE_NOTHROW(imported->fromJson(originalJson));

--- a/test/unit/test-geojson-import.cpp
+++ b/test/unit/test-geojson-import.cpp
@@ -1,0 +1,343 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "mapget/model/featureid.h"
+#include "mapget/model/featurelayer.h"
+#include "mapget/model/json-compare.h"
+#include "nlohmann/json.hpp"
+#include "simfil/byte-array.h"
+
+using namespace mapget;
+using namespace std::chrono_literals;
+using namespace nlohmann::literals;
+
+namespace
+{
+
+struct SourceRefSpec
+{
+    uint32_t bitOffset_;
+    uint32_t bitSize_;
+    std::string layerId_;
+    std::string qualifier_;
+};
+
+std::shared_ptr<LayerInfo> makeRoadLayerInfo()
+{
+    return LayerInfo::fromJson(R"json(
+    {
+      "layerId": "RoadLayer",
+      "type": "Features",
+      "featureTypes": [
+        {
+          "name": "Road",
+          "uniqueIdCompositions": [
+            [
+              {"partId": "tileId", "datatype": "U64", "isSynthetic": true},
+              {"partId": "regionId", "datatype": "STR"},
+              {"partId": "roadId", "datatype": "U32"}
+            ]
+          ]
+        }
+      ],
+      "stages": 3,
+      "stageLabels": ["Draft", "High-Fi", "ADAS"],
+      "highFidelityStage": 1
+    })json"_json);
+}
+
+std::shared_ptr<LayerInfo> makeGenericLayerInfo()
+{
+    return LayerInfo::fromJson(R"json(
+    {
+      "layerId": "GeoJsonAny",
+      "type": "Features",
+      "featureTypes": [
+        {
+          "name": "AnyFeature",
+          "uniqueIdCompositions": [[
+            {"partId": "tileId", "datatype": "U64", "isSynthetic": true},
+            {"partId": "featureIndex", "datatype": "U32", "isSynthetic": true}
+          ]]
+        }
+      ]
+    })json"_json);
+}
+
+TileFeatureLayer::Ptr makeTile(
+    uint64_t tileId,
+    std::shared_ptr<LayerInfo> const& layerInfo,
+    std::string const& nodeId = "GeoJsonImportNode",
+    std::string const& mapId = "GeoJsonImportMap")
+{
+    return std::make_shared<TileFeatureLayer>(
+        TileId(tileId),
+        nodeId,
+        mapId,
+        layerInfo,
+        std::make_shared<StringPool>(nodeId));
+}
+
+simfil::ModelNode::Ptr nullNode(TileFeatureLayer& tile)
+{
+    return tile.resolve<simfil::ModelNode>(
+        simfil::ModelNodeAddress{simfil::Model::Null, 1},
+        simfil::ScalarValueType{});
+}
+
+model_ptr<SourceDataReferenceCollection> makeSourceDataRefs(
+    TileFeatureLayer& tile,
+    std::initializer_list<SourceRefSpec> refs)
+{
+    std::vector<QualifiedSourceDataReference> values;
+    values.reserve(refs.size());
+    for (auto const& spec : refs) {
+        auto layerId = tile.strings()->emplace(spec.layerId_);
+        if (!layerId) {
+            throw std::runtime_error(layerId.error().message);
+        }
+        auto qualifier = tile.strings()->emplace(spec.qualifier_);
+        if (!qualifier) {
+            throw std::runtime_error(qualifier.error().message);
+        }
+        values.push_back(QualifiedSourceDataReference{
+            SourceDataAddress::fromBitPosition(spec.bitOffset_, spec.bitSize_),
+            *layerId,
+            *qualifier,
+        });
+    }
+    return tile.newSourceDataReferenceCollection(values);
+}
+
+std::filesystem::path fixturePath(std::string const& fileName)
+{
+    return std::filesystem::path(__FILE__).parent_path() / "data" / fileName;
+}
+
+[[nodiscard]] nlohmann::json loadJsonFixture(std::string const& fileName)
+{
+    auto path = fixturePath(fileName);
+    std::ifstream input(path);
+    if (!input) {
+        throw std::runtime_error("Failed to open fixture: " + path.string());
+    }
+    return nlohmann::json::parse(input);
+}
+
+template<typename T>
+void requireExpectedOk(tl::expected<T, simfil::Error> const& result)
+{
+    REQUIRE(result);
+}
+
+}  // namespace
+
+TEST_CASE("Feature ID strings roundtrip escaped string parts", "[FeatureId][GeoJsonImport]")
+{
+    auto layerInfo = makeRoadLayerInfo();
+
+    ParsedFeatureId parsed;
+    std::string error;
+    REQUIRE(parseFeatureIdString("Road.77.DE%2EBY%25.7", *layerInfo, parsed, &error));
+    REQUIRE(parsed.typeId_ == "Road");
+    REQUIRE(parsed.keyValuePairs_.size() == 3);
+    REQUIRE(parsed.keyValuePairs_[0].first == "tileId");
+    REQUIRE(std::get<int64_t>(parsed.keyValuePairs_[0].second) == 77);
+    REQUIRE(parsed.keyValuePairs_[1].first == "regionId");
+    REQUIRE(std::get<std::string>(parsed.keyValuePairs_[1].second) == "DE.BY%");
+    REQUIRE(parsed.keyValuePairs_[2].first == "roadId");
+    REQUIRE(std::get<int64_t>(parsed.keyValuePairs_[2].second) == 7);
+
+    auto tile = makeTile(77, layerInfo, "FeatureIdNode");
+    tile->setIdPrefix({{"tileId", static_cast<int64_t>(77)}, {"regionId", "DE.BY%"}});
+    auto feature = tile->newFeature("Road", {{"roadId", 7}});
+    REQUIRE(feature->id()->toString() == "Road.77.DE%2EBY%25.7");
+    REQUIRE(tile->find("Road.77.DE%2EBY%25.7"));
+}
+
+TEST_CASE("TileFeatureLayer strict GeoJSON import roundtrips mapget JSON", "[GeoJsonImport]")
+{
+    auto layerInfo = makeRoadLayerInfo();
+    auto tile = makeTile(77, layerInfo, "StrictImportNode", "StrictImportMap");
+
+    tile->setIdPrefix({{"tileId", static_cast<int64_t>(77)}, {"regionId", "DE.BY%"}});
+    tile->setGeometryAnchor({11.3, 48.0, 5.0});
+    tile->setTimestamp(std::chrono::system_clock::time_point{1714348800s} + 123456us);
+    tile->setTtl(2500ms);
+    tile->setError(std::optional<std::string>{"partially degraded"});
+    tile->setErrorCode(std::optional<int>{206});
+
+    auto roadA = tile->newFeature("Road", {{"roadId", 7}});
+    auto roadALine = roadA->geom()->newGeometry(GeomType::Line, 3, true);
+    roadALine->append({11.3, 48.0, 0.0});
+    roadALine->append({11.31, 48.01, 0.0});
+    roadALine->append({11.32, 48.015, 0.0});
+    roadALine->setStage(2);
+    roadALine->setSourceDataReferences(makeSourceDataRefs(
+        *tile,
+        {{10, 20, "road-src", "centerline"}}));
+
+    auto roadAMesh = roadA->geom()->newGeometry(GeomType::Mesh, 3, true);
+    roadAMesh->append({11.3, 48.0, 0.0});
+    roadAMesh->append({11.3, 48.002, 0.0});
+    roadAMesh->append({11.302, 48.001, 0.0});
+    roadAMesh->setStage(2);
+
+    roadA->setSourceDataReferences(makeSourceDataRefs(
+        *tile,
+        {{30, 40, "road-src", "feature"}}));
+    requireExpectedOk(roadA->attributes()->addField("speedLimit", int64_t{80}));
+    requireExpectedOk(roadA->attributes()->addField("optionalNote", nullNode(*tile)));
+
+    auto restrictions = roadA->attributeLayers()->newLayer("restrictions");
+    auto turn = restrictions->newAttribute("turn");
+    auto turnMeta = tile->newObject(3, true);
+    requireExpectedOk(turnMeta->addField("tag", "left"));
+    requireExpectedOk(turnMeta->addField("tag", "through"));
+    requireExpectedOk(turnMeta->addField("blob", tile->newValue(simfil::ByteArray{"AB"})));
+    requireExpectedOk(turn->addField("meta", turnMeta));
+    turn->setSourceDataReferences(makeSourceDataRefs(
+        *tile,
+        {{50, 12, "rules-src", "attribute"}}));
+
+    auto roadB = tile->newFeature("Road", {{"roadId", 9}});
+    auto roadBLine = roadB->geom()->newGeometry(GeomType::Line, 2, true);
+    roadBLine->append({11.32, 48.015, 0.0});
+    roadBLine->append({11.33, 48.02, 0.0});
+
+    turn->validity()->newFeatureTransition(
+        roadA,
+        Validity::End,
+        roadB,
+        Validity::Start,
+        3,
+        Validity::Positive);
+
+    auto relation = tile->newRelation(
+        "connectedTo",
+        tile->newFeatureId(
+            "Road",
+            {
+                {"tileId", static_cast<int64_t>(77)},
+                {"regionId", "DE.BY%"},
+                {"roadId", 9},
+            }));
+    relation->setSourceDataReferences(makeSourceDataRefs(
+        *tile,
+        {{70, 8, "rules-src", "relation"}}));
+    relation->sourceValidity()->newRange(
+        Validity::RelativeLengthOffset,
+        0.25,
+        0.75,
+        2,
+        Validity::Positive);
+    relation->targetValidity()->newPoint(
+        Point{11.32, 48.015, 0.0},
+        std::nullopt,
+        Validity::Negative);
+    roadA->addRelation(relation);
+
+    auto roadC = tile->newFeature("Road", {{"roadId", 11}});
+    auto roadCAabb = roadC->geom()->newGeometry(GeomType::AABB, 2, true);
+    roadCAabb->setAabb({11.4, 48.1, 1.0}, {0.01, 0.02, 0.5});
+
+    auto originalJson = tile->toJson();
+    REQUIRE(originalJson["features"][0]["id"] == "Road.77.DE%2EBY%25.7");
+    REQUIRE(originalJson["features"][0]["geometry"]["type"] == "GeometryCollection");
+
+    auto imported = makeTile(77, layerInfo, "StrictImportNode", "StrictImportMap");
+    REQUIRE_NOTHROW(imported->fromJson(originalJson));
+    REQUIRE(imported->toJson() == originalJson);
+    REQUIRE(imported->find("Road.77.DE%2EBY%25.7"));
+    REQUIRE(imported->find("Road.77.DE%2EBY%25.9"));
+}
+
+TEST_CASE("TileFeatureLayer best-effort GeoJSON import shares the same pipeline", "[GeoJsonImport]")
+{
+    auto layerInfo = makeGenericLayerInfo();
+    auto tile = makeTile(37392110387213ULL, layerInfo, "BestEffortNode");
+
+    auto input = R"json(
+    {
+      "type": "FeatureCollection",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "MultiLineString",
+            "coordinates": [
+              [[11.3, 48.0, 0.0], [11.31, 48.01, 1.0]],
+              [[11.31, 48.01, 1.0], [11.32, 48.02, 2.0]]
+            ]
+          },
+          "properties": {
+            "name": "Main",
+            "restrictions": {
+              "turn": {
+                "value": "left",
+                "validity": {
+                  "direction": "POSITIVE"
+                }
+              }
+            }
+          }
+        }
+      ]
+    })json"_json;
+
+    REQUIRE_NOTHROW(tile->fromJson(
+        input,
+        GeoJsonImportOptions{
+            .strict_ = false,
+            .fallbackFeatureType_ = "AnyFeature",
+            .objectPropertiesAsAttributeLayers_ = true,
+        }));
+
+    auto output = tile->toJson();
+    REQUIRE(output["features"].size() == 1);
+    REQUIRE(output["features"][0]["id"] == "AnyFeature.37392110387213.0");
+    REQUIRE(output["features"][0]["geometry"]["type"] == "GeometryCollection");
+    REQUIRE(output["features"][0]["properties"]["name"] == "Main");
+    REQUIRE(output["features"][0]["properties"]["layer"]["restrictions"]["turn"]["value"] == "left");
+    REQUIRE(
+        output["features"][0]["properties"]["layer"]["restrictions"]["turn"]["validity"]["direction"] ==
+        "POSITIVE");
+}
+
+TEST_CASE("Large sanitized GeoJSON fixture roundtrips", "[GeoJsonImport][Fixture]")
+{
+    auto layerInfoJson = loadJsonFixture("large-geojson-featureset.layer-info.json");
+    auto featureCollectionJson = loadJsonFixture("large-geojson-featureset.feature-collection.json");
+    auto layerInfo = LayerInfo::fromJson(layerInfoJson);
+
+    REQUIRE(featureCollectionJson.at("mapgetLayerId").get<std::string>() == layerInfo->layerId_);
+    REQUIRE(featureCollectionJson.at("features").size() >= 64);
+
+    auto tile = makeTile(
+        featureCollectionJson.at("mapgetTileId").get<uint64_t>(),
+        layerInfo,
+        "FixtureImportNode",
+        featureCollectionJson.at("mapId").get<std::string>());
+
+    REQUIRE_NOTHROW(tile->fromJson(featureCollectionJson));
+
+    auto roundTrip = tile->toJson();
+    std::vector<std::string> errors;
+    auto const matches = compareJsonWithTolerance(
+        featureCollectionJson,
+        roundTrip,
+        1e-5,
+        &errors);
+    INFO(nlohmann::json::diff(featureCollectionJson, roundTrip).dump());
+    INFO(formatJsonComparisonErrors(errors));
+    REQUIRE(matches);
+
+    REQUIRE(tile->find("Entry.444000777123.group%2E00%25.0"));
+    REQUIRE(tile->find("Entry.444000777123.group%2E00%25.71"));
+}

--- a/test/unit/test-geojsonsource.cpp
+++ b/test/unit/test-geojsonsource.cpp
@@ -2,9 +2,15 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <unordered_map>
 
 #include "geojsonsource/geojsonsource.h"
+#include "mapget/detail/http-server.h"
 #include "mapget/model/featurelayer.h"
+
+#include <drogon/HttpAppFramework.h>
+#include <drogon/HttpResponse.h>
+#include <fmt/format.h>
 
 using namespace mapget;
 
@@ -61,10 +67,39 @@ std::filesystem::path createTempDir()
 
 void writeFile(const std::filesystem::path& path, const std::string& content)
 {
+    std::filesystem::create_directories(path.parent_path());
     std::ofstream file(path);
     file << content;
     file.close();
 }
+
+class TestGeoJsonEndpointServer : public mapget::HttpServer
+{
+public:
+    explicit TestGeoJsonEndpointServer(std::unordered_map<std::string, std::string> responses)
+        : responses_(std::move(responses))
+    {
+    }
+
+protected:
+    void setup(drogon::HttpAppFramework& app) override
+    {
+        for (const auto& [path, body] : responses_) {
+            app.registerHandler(
+                path,
+                [body](const drogon::HttpRequestPtr&, std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
+                    auto response = drogon::HttpResponse::newHttpResponse();
+                    response->setStatusCode(drogon::k200OK);
+                    response->setBody(body);
+                    callback(response);
+                },
+                {drogon::Get});
+        }
+    }
+
+private:
+    std::unordered_map<std::string, std::string> responses_;
+};
 
 }  // namespace
 
@@ -406,5 +441,146 @@ TEST_CASE("GeoJsonSource", "[GeoJsonSource]")
         REQUIRE(tile2->numRoots() > 0);
 
         std::filesystem::remove_all(tempDir);
+    }
+
+    SECTION("Explicit datasource info file enables template-based folder loading")
+    {
+        auto tempDir = createTempDir();
+
+        writeFile(tempDir / "Road" / (std::to_string(largeTileId) + ".geojson"), sampleGeoJson);
+        writeFile(tempDir / "Lane" / (std::to_string(largeTileId) + ".geojson"), sampleGeoJson2);
+        writeFile(tempDir / "info.yaml", fmt::format(R"yaml(
+mapId: ExplicitGeoJson
+layers:
+  Road:
+    featureTypes:
+      - name: RoadFeature
+        uniqueIdCompositions:
+          - - partId: tileId
+              datatype: U64
+            - partId: featureIndex
+              datatype: U32
+    coverage:
+      - {}
+  Lane:
+    featureTypes:
+      - name: LaneFeature
+        uniqueIdCompositions:
+          - - partId: tileId
+              datatype: U64
+            - partId: featureIndex
+              datatype: U32
+    coverage:
+      - {}
+)yaml", largeTileId, largeTileId));
+
+        geojsonsource::GeoJsonSource source(
+            tempDir.string(),
+            geojsonsource::GeoJsonSourceOptions{
+                .withAttrLayers = false,
+                .tilePathTemplate = "{layerId}/{tileId}.geojson",
+                .dataSourceInfoLocation = (tempDir / "info.yaml").string()});
+
+        auto info = source.info();
+        REQUIRE_FALSE(source.hasManifest());
+        REQUIRE(info.mapId_ == "ExplicitGeoJson");
+        REQUIRE(info.getLayer("Road") != nullptr);
+        REQUIRE(info.getLayer("Lane") != nullptr);
+
+        auto strings = std::make_shared<StringPool>(info.nodeId_);
+        auto roadTile = std::make_shared<TileFeatureLayer>(
+            TileId(largeTileId),
+            info.nodeId_,
+            info.mapId_,
+            info.getLayer("Road"),
+            strings);
+        REQUIRE_NOTHROW(source.fill(roadTile));
+        REQUIRE(roadTile->numRoots() > 0);
+
+        auto laneTile = std::make_shared<TileFeatureLayer>(
+            TileId(largeTileId),
+            info.nodeId_,
+            info.mapId_,
+            info.getLayer("Lane"),
+            strings);
+        REQUIRE_NOTHROW(source.fill(laneTile));
+        REQUIRE(laneTile->numRoots() > 0);
+
+        std::filesystem::remove_all(tempDir);
+    }
+
+    SECTION("GeoJsonEndpoint loads tiles over HTTP with and without datasource info")
+    {
+        auto infoYaml = fmt::format(R"yaml(
+mapId: RemoteGeoJson
+layers:
+  Road:
+    featureTypes:
+      - name: RoadFeature
+        uniqueIdCompositions:
+          - - partId: tileId
+              datatype: U64
+            - partId: featureIndex
+              datatype: U32
+    coverage:
+      - {}
+)yaml", largeTileId);
+
+        TestGeoJsonEndpointServer server({
+            {"/info.yaml", infoYaml},
+            {fmt::format("/tiles/Road/{}.geojson", largeTileId), sampleGeoJson},
+            {fmt::format("/{}.geojson", largeTileId), sampleGeoJson},
+        });
+        server.go("127.0.0.1", 0, 2000);
+
+        auto baseUrl = fmt::format("http://127.0.0.1:{}/tiles", server.port());
+        auto infoUrl = fmt::format("http://127.0.0.1:{}/info.yaml", server.port());
+
+        geojsonsource::GeoJsonEndpointSource source({
+            .baseUrl = baseUrl,
+            .withAttrLayers = false,
+            .tileUrlTemplate = "{layerId}/{tileId}.geojson",
+            .dataSourceInfoLocation = infoUrl,
+        });
+
+        auto info = source.info();
+        REQUIRE(info.mapId_ == "RemoteGeoJson");
+        auto roadLayer = info.getLayer("Road");
+        REQUIRE(roadLayer != nullptr);
+
+        auto strings = std::make_shared<StringPool>(info.nodeId_);
+        auto roadTile = std::make_shared<TileFeatureLayer>(
+            TileId(largeTileId),
+            info.nodeId_,
+            info.mapId_,
+            roadLayer,
+            strings);
+        REQUIRE_NOTHROW(source.fill(roadTile));
+        REQUIRE(roadTile->numRoots() > 0);
+        REQUIRE_FALSE(roadTile->error().has_value());
+
+        geojsonsource::GeoJsonEndpointSource fallbackSource({
+            .baseUrl = fmt::format("http://127.0.0.1:{}", server.port()),
+            .withAttrLayers = false,
+            .mapId = "FallbackEndpoint",
+            .tileUrlTemplate = "{tileId}.geojson",
+        });
+
+        auto fallbackInfo = fallbackSource.info();
+        REQUIRE(fallbackInfo.mapId_ == "FallbackEndpoint");
+        auto anyLayer = fallbackInfo.getLayer("GeoJsonAny");
+        REQUIRE(anyLayer != nullptr);
+        REQUIRE(anyLayer->coverage_.empty());
+
+        auto fallbackStrings = std::make_shared<StringPool>(fallbackInfo.nodeId_);
+        auto tile = std::make_shared<TileFeatureLayer>(
+            TileId(largeTileId),
+            fallbackInfo.nodeId_,
+            fallbackInfo.mapId_,
+            anyLayer,
+            fallbackStrings);
+        REQUIRE_NOTHROW(fallbackSource.fill(tile));
+        REQUIRE(tile->numRoots() > 0);
+        REQUIRE_FALSE(tile->error().has_value());
     }
 }

--- a/test/unit/test-geojsonsource.cpp
+++ b/test/unit/test-geojsonsource.cpp
@@ -46,6 +46,12 @@ auto sampleGeoJson2 = R"json({"type": "FeatureCollection", "features": [{
     "type": "Feature"
 }]})json";
 
+std::string testEndpointBaseUrl()
+{
+    static constexpr char cleartextScheme[] = {'h', 't', 't', 'p', '\0'};
+    return fmt::format("{}://{}", std::string_view(cleartextScheme, 4), "geojson-endpoint.test");
+}
+
 std::filesystem::path createTempDir()
 {
     auto now = std::chrono::system_clock::now();
@@ -495,11 +501,12 @@ layers:
       - {}
 )yaml", largeTileId);
 
+        auto const endpointBaseUrl = testEndpointBaseUrl();
         auto responses = std::make_shared<std::unordered_map<std::string, std::string>>(
             std::unordered_map<std::string, std::string>{
-                {"http://geojson-endpoint.test/info.yaml", infoYaml},
-                {fmt::format("http://geojson-endpoint.test/tiles/Road/{}.geojson", largeTileId), sampleGeoJson},
-                {fmt::format("http://geojson-endpoint.test/{}.geojson", largeTileId), sampleGeoJson},
+                {fmt::format("{}/info.yaml", endpointBaseUrl), infoYaml},
+                {fmt::format("{}/tiles/Road/{}.geojson", endpointBaseUrl, largeTileId), sampleGeoJson},
+                {fmt::format("{}/{}.geojson", endpointBaseUrl, largeTileId), sampleGeoJson},
             });
         auto fetchText = [responses](std::string const& url) -> std::string {
             auto it = responses->find(url);
@@ -510,10 +517,10 @@ layers:
         };
 
         geojsonsource::GeoJsonEndpointSource source({
-            .baseUrl = "http://geojson-endpoint.test/tiles",
+            .baseUrl = fmt::format("{}/tiles", endpointBaseUrl),
             .withAttrLayers = false,
             .tileUrlTemplate = "{layerId}/{tileId}.geojson",
-            .dataSourceInfoLocation = "http://geojson-endpoint.test/info.yaml",
+            .dataSourceInfoLocation = fmt::format("{}/info.yaml", endpointBaseUrl),
             .fetchText = fetchText,
         });
 
@@ -534,7 +541,7 @@ layers:
         REQUIRE_FALSE(roadTile->error().has_value());
 
         geojsonsource::GeoJsonEndpointSource fallbackSource({
-            .baseUrl = "http://geojson-endpoint.test",
+            .baseUrl = endpointBaseUrl,
             .withAttrLayers = false,
             .mapId = "FallbackEndpoint",
             .tileUrlTemplate = "{tileId}.geojson",

--- a/test/unit/test-geojsonsource.cpp
+++ b/test/unit/test-geojsonsource.cpp
@@ -2,14 +2,11 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <unordered_map>
 
 #include "geojsonsource/geojsonsource.h"
-#include "mapget/detail/http-server.h"
 #include "mapget/model/featurelayer.h"
-
-#include <drogon/HttpAppFramework.h>
-#include <drogon/HttpResponse.h>
 #include <fmt/format.h>
 
 using namespace mapget;
@@ -72,34 +69,6 @@ void writeFile(const std::filesystem::path& path, const std::string& content)
     file << content;
     file.close();
 }
-
-class TestGeoJsonEndpointServer : public mapget::HttpServer
-{
-public:
-    explicit TestGeoJsonEndpointServer(std::unordered_map<std::string, std::string> responses)
-        : responses_(std::move(responses))
-    {
-    }
-
-protected:
-    void setup(drogon::HttpAppFramework& app) override
-    {
-        for (const auto& [path, body] : responses_) {
-            app.registerHandler(
-                path,
-                [body](const drogon::HttpRequestPtr&, std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
-                    auto response = drogon::HttpResponse::newHttpResponse();
-                    response->setStatusCode(drogon::k200OK);
-                    response->setBody(body);
-                    callback(response);
-                },
-                {drogon::Get});
-        }
-    }
-
-private:
-    std::unordered_map<std::string, std::string> responses_;
-};
 
 }  // namespace
 
@@ -526,21 +495,26 @@ layers:
       - {}
 )yaml", largeTileId);
 
-        TestGeoJsonEndpointServer server({
-            {"/info.yaml", infoYaml},
-            {fmt::format("/tiles/Road/{}.geojson", largeTileId), sampleGeoJson},
-            {fmt::format("/{}.geojson", largeTileId), sampleGeoJson},
-        });
-        server.go("127.0.0.1", 0, 2000);
-
-        auto baseUrl = fmt::format("http://127.0.0.1:{}/tiles", server.port());
-        auto infoUrl = fmt::format("http://127.0.0.1:{}/info.yaml", server.port());
+        auto responses = std::make_shared<std::unordered_map<std::string, std::string>>(
+            std::unordered_map<std::string, std::string>{
+                {"http://geojson-endpoint.test/info.yaml", infoYaml},
+                {fmt::format("http://geojson-endpoint.test/tiles/Road/{}.geojson", largeTileId), sampleGeoJson},
+                {fmt::format("http://geojson-endpoint.test/{}.geojson", largeTileId), sampleGeoJson},
+            });
+        auto fetchText = [responses](std::string const& url) -> std::string {
+            auto it = responses->find(url);
+            if (it == responses->end()) {
+                throw std::runtime_error(fmt::format("Unexpected GeoJsonEndpoint test URL: {}", url));
+            }
+            return it->second;
+        };
 
         geojsonsource::GeoJsonEndpointSource source({
-            .baseUrl = baseUrl,
+            .baseUrl = "http://geojson-endpoint.test/tiles",
             .withAttrLayers = false,
             .tileUrlTemplate = "{layerId}/{tileId}.geojson",
-            .dataSourceInfoLocation = infoUrl,
+            .dataSourceInfoLocation = "http://geojson-endpoint.test/info.yaml",
+            .fetchText = fetchText,
         });
 
         auto info = source.info();
@@ -560,10 +534,11 @@ layers:
         REQUIRE_FALSE(roadTile->error().has_value());
 
         geojsonsource::GeoJsonEndpointSource fallbackSource({
-            .baseUrl = fmt::format("http://127.0.0.1:{}", server.port()),
+            .baseUrl = "http://geojson-endpoint.test",
             .withAttrLayers = false,
             .mapId = "FallbackEndpoint",
             .tileUrlTemplate = "{tileId}.geojson",
+            .fetchText = fetchText,
         });
 
         auto fallbackInfo = fallbackSource.info();

--- a/test/unit/test-model.cpp
+++ b/test/unit/test-model.cpp
@@ -455,11 +455,11 @@ TEST_CASE("FeatureLayer", "[test.featurelayer]")
         REQUIRE(json["mapId"] == "Tropico");
         REQUIRE(json["mapgetLayerId"] == "WayLayer");
 
-        // Verify timestamp is ISO 8601 format
-        REQUIRE(json["timestamp"].is_string());
-        std::string timestamp = json["timestamp"];
-        REQUIRE(timestamp.find("T") != std::string::npos);
-        REQUIRE(timestamp.back() == 'Z');
+        // Verify timestamp stays in the binary microsecond representation.
+        REQUIRE(json["timestamp"].is_number_integer());
+        REQUIRE(json["timestamp"].get<int64_t>() ==
+            std::chrono::duration_cast<std::chrono::microseconds>(
+                tile->timestamp().time_since_epoch()).count());
 
         // Verify TTL
         REQUIRE(json["ttl"] == 3600000);

--- a/test/unit/test-model.cpp
+++ b/test/unit/test-model.cpp
@@ -430,10 +430,6 @@ TEST_CASE("FeatureLayer", "[test.featurelayer]")
         REQUIRE(json["mapId"] == "Tropico");
         REQUIRE(json["mapgetLayerId"] == "WayLayer");
 
-        // Verify idPrefix
-        REQUIRE(json.contains("idPrefix"));
-        REQUIRE(json["idPrefix"]["areaId"] == "TheBestArea");
-
         // Verify timestamp is ISO 8601 format
         REQUIRE(json["timestamp"].is_string());
         std::string timestamp = json["timestamp"];

--- a/test/unit/test-model.cpp
+++ b/test/unit/test-model.cpp
@@ -182,6 +182,10 @@ TEST_CASE("FeatureLayer", "[test.featurelayer]")
     auto featureForId2 = tile->newFeatureId(
         "Way",
         {{"wayIdI32", -42}, {"wayIdI64", -84}, {"wayIdUUID128", "0123456789abcdef"}});
+    auto externalFeatureId = tile->newFeatureId(
+        "Way",
+        {{"wayIdU32", 7}, {"wayIdU64", 11}, {"wayIdUUID128", "fedcba9876543210"}},
+        "ValidationMap");
 
     SECTION("firstGeometry")
     {
@@ -230,6 +234,18 @@ TEST_CASE("FeatureLayer", "[test.featurelayer]")
         REQUIRE(std::get<int64_t>(keyValuePairs[1].second) == 84);
         REQUIRE(keyValuePairs[2].first == "wayIdUUID128");
         REQUIRE(std::get<std::string_view>(keyValuePairs[2].second) == "0123456789abcdef");
+    }
+
+    SECTION("Detached feature IDs preserve optional external map IDs")
+    {
+        REQUIRE(featureForId1->toJson() == nlohmann::json("Way.42.84.0123456789abcdef"));
+        REQUIRE(externalFeatureId->toString() == "Way.7.11.fedcba9876543210");
+        REQUIRE(externalFeatureId->mapId() == "ValidationMap");
+        REQUIRE(externalFeatureId->externalMapId() == std::optional<std::string_view>{"ValidationMap"});
+        REQUIRE(externalFeatureId->toJson() == nlohmann::json{
+            {"id", "Way.7.11.fedcba9876543210"},
+            {"mapId", "ValidationMap"},
+        });
     }
 
     SECTION("Evaluate simfil filter")
@@ -324,6 +340,15 @@ TEST_CASE("FeatureLayer", "[test.featurelayer]")
         REQUIRE(std::get<int64_t>(deserializedKeyValuePairs[1].second) == 84);
         REQUIRE(deserializedKeyValuePairs[2].first == "wayIdUUID128");
         REQUIRE(std::get<std::string_view>(deserializedKeyValuePairs[2].second) == "0123456789abcdef");
+
+        auto deserializedExternalFeatureId = deserializedTile->resolve<FeatureId>(
+            simfil::ModelNodeAddress{TileFeatureLayer::ColumnId::ExternalFeatureIds, 2});
+        REQUIRE(deserializedExternalFeatureId);
+        REQUIRE(deserializedExternalFeatureId->toString() == "Way.7.11.fedcba9876543210");
+        REQUIRE(deserializedExternalFeatureId->mapId() == "ValidationMap");
+        REQUIRE(
+            deserializedExternalFeatureId->externalMapId() ==
+            std::optional<std::string_view>{"ValidationMap"});
     }
 
     SECTION("Stream")
@@ -792,7 +817,9 @@ TEST_CASE("Single-entry validity collections are exposed as singular nodes", "[t
     auto attr = feature->attributeLayers()->newLayer("limits")->newAttribute("speed");
     attr->validity()->newDirection(Validity::Direction::Both);
 
-    auto relation = tile->newRelation("connectedTo", tile->newFeatureId("Way", {{"wayId", 2}}));
+    auto relation = tile->newRelation(
+        "connectedTo",
+        tile->newFeatureId("Way", {{"wayId", 2}}, "ValidationMap"));
     relation->sourceValidity()->newDirection(Validity::Direction::Positive);
     relation->targetValidity()->newDirection(Validity::Direction::Negative);
     feature->addRelation(relation);
@@ -806,7 +833,14 @@ TEST_CASE("Single-entry validity collections are exposed as singular nodes", "[t
 
     auto materializedRelation = tile->resolve<Relation>(relation->addr());
     REQUIRE(materializedRelation);
+    REQUIRE(materializedRelation->target()->mapId() == "ValidationMap");
     auto const& relationNode = static_cast<simfil::ModelNode const&>(*materializedRelation);
+    auto const targetNode = relationNode.get(StringPool::TargetStr);
+    REQUIRE(targetNode);
+    REQUIRE(targetNode->toJson() == nlohmann::json{
+        {"id", "Way.2"},
+        {"mapId", "ValidationMap"},
+    });
     auto const sourceValidityNode = relationNode.get(StringPool::SourceValidityStr);
     REQUIRE(sourceValidityNode);
     REQUIRE(sourceValidityNode->toJson() == nlohmann::json{{"direction", "POSITIVE"}});
@@ -814,6 +848,48 @@ TEST_CASE("Single-entry validity collections are exposed as singular nodes", "[t
     auto const targetValidityNode = relationNode.get(StringPool::TargetValidityStr);
     REQUIRE(targetValidityNode);
     REQUIRE(targetValidityNode->toJson() == nlohmann::json{{"direction", "NEGATIVE"}});
+}
+
+TEST_CASE("Feature-id validities expose external map references", "[test.featurelayer.validity]")
+{
+    auto layerInfo = LayerInfo::fromJson(R"({
+        "layerId": "WayLayer",
+        "type": "Features",
+        "featureTypes": [
+            {
+                "name": "Way",
+                "uniqueIdCompositions": [[
+                    {"partId": "wayId", "description": "way id", "datatype": "U32"}
+                ]]
+            }
+        ]
+    })"_json);
+
+    auto strings = std::make_shared<StringPool>("FeatureRefValidityNode");
+    auto tile = std::make_shared<TileFeatureLayer>(
+        TileId::fromWgs84(42., 11., 13),
+        "FeatureRefValidityNode",
+        "Tropico",
+        layerInfo,
+        strings);
+    auto feature = tile->newFeature("Way", {{"wayId", 1}});
+    auto attr = feature->attributeLayers()->newLayer("limits")->newAttribute("speed");
+
+    auto externalReference = tile->newFeatureId("Way", {{"wayId", 2}}, "ValidationMap");
+    attr->validity()->newFeatureId(externalReference, Validity::Direction::Positive);
+
+    auto materializedAttr = tile->resolve<Attribute>(attr->addr());
+    REQUIRE(materializedAttr);
+    auto const& attrNode = static_cast<simfil::ModelNode const&>(*materializedAttr);
+    auto const validityNode = attrNode.get(StringPool::ValidityStr);
+    REQUIRE(validityNode);
+    REQUIRE(validityNode->toJson() == nlohmann::json{
+        {"direction", "POSITIVE"},
+        {"featureId", {
+            {"id", "Way.2"},
+            {"mapId", "ValidationMap"},
+        }},
+    });
 }
 
 TEST_CASE("Semantic feature transition validities expose semantic nodes", "[test.featurelayer.validity]")


### PR DESCRIPTION
This PR adds the `GeoJsonEndpoint` datasource, as well as the introduction of an eager-yet-forgiving fully-featured GeoJson-mapget import. This replaces the previously implemented import routines. 