### PR TITLE
Use schema paths for auto-wildcard queries

### DIFF
--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -35,7 +35,7 @@ if (NOT "${_mapget_simfil_source_dir}" STREQUAL "")
             "SIMFIL_SHARED OFF")
 else()
 CPMAddPackage(
-        URI "gh:Klebert-Engineering/simfil#release/1.0.0@7a27ead"
+        URI "gh:Klebert-Engineering/simfil#schema-auto-wildcard@a58b5dc"
         OPTIONS
             "SIMFIL_WITH_MODEL_JSON ON"
             "SIMFIL_SHARED OFF")

--- a/libs/model/include/mapget/model/schemaregistry.h
+++ b/libs/model/include/mapget/model/schemaregistry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <span>
@@ -67,6 +68,19 @@ public:
 
     /** Return enum-like string symbols reachable from this schema node. */
     [[nodiscard]] std::span<const std::string> nestedEnumSymbols(simfil::SchemaId schemaId) const;
+
+    /** Return enum-like string symbols declared directly by this schema node. */
+    [[nodiscard]] std::span<const std::string> directEnumSymbols(simfil::SchemaId schemaId) const;
+
+    /** Visit direct fields and their possible child schemas. */
+    void forEachDirectField(
+        simfil::SchemaId schemaId,
+        const std::function<void(std::string_view, std::span<const simfil::SchemaId>)>& fn) const;
+
+    /** Visit possible array element schemas. */
+    void forEachElementSchema(
+        simfil::SchemaId schemaId,
+        const std::function<void(simfil::SchemaId)>& fn) const;
 
     /** Resolve the Feature object schema for a concrete mapget feature type. */
     [[nodiscard]] simfil::SchemaId featureSchema(std::string_view featureType) const;

--- a/libs/model/include/mapget/model/schemaregistry.h
+++ b/libs/model/include/mapget/model/schemaregistry.h
@@ -39,6 +39,29 @@ public:
         std::string metaType_;
     };
 
+    /** Owner classification for a schema path starting at a known root. */
+    enum class PathOwnerKind {
+        Unknown,
+        Feature,
+        Attribute,
+    };
+
+    /** Concrete attribute context owning a schema path. */
+    struct AttributePathOwner
+    {
+        std::string featureType_;
+        std::string attributeLayerName_;
+        std::string attributeName_;
+        simfil::SchemaId attributeSchema_ = simfil::NoSchemaId;
+    };
+
+    /** Result returned by ownerForPath for downstream scope decisions. */
+    struct PathOwner
+    {
+        PathOwnerKind kind_ = PathOwnerKind::Unknown;
+        AttributePathOwner attribute_;
+    };
+
     /** Parse all supported schema branches and assign deterministic SchemaIds. */
     explicit SchemaRegistry(nlohmann::json const& schema);
 
@@ -72,6 +95,11 @@ public:
     /** Return enum-like string symbols declared directly by this schema node. */
     [[nodiscard]] std::span<const std::string> directEnumSymbols(simfil::SchemaId schemaId) const;
 
+    /** Return enum/zserio type names attached to a constant-like completion candidate. */
+    [[nodiscard]] std::vector<std::string> constantTypeNames(
+        simfil::SchemaId schemaId,
+        std::string_view symbolName) const;
+
     /** Visit direct fields and their possible child schemas. */
     void forEachDirectField(
         simfil::SchemaId schemaId,
@@ -96,6 +124,12 @@ public:
         simfil::SchemaId parent,
         std::string_view fieldName,
         std::optional<simfil::Schema::Kind> preferredKind = std::nullopt) const;
+
+    /** Classify whether a path belongs to the feature itself or to an attribute branch. */
+    [[nodiscard]] PathOwner ownerForPath(
+        std::string_view featureType,
+        simfil::SchemaId rootSchema,
+        std::span<const std::string> fieldPath) const;
 
 private:
     std::shared_ptr<Impl> impl_;

--- a/libs/model/include/mapget/model/simfilutil.h
+++ b/libs/model/include/mapget/model/simfilutil.h
@@ -18,7 +18,7 @@ void installSchemaRegistry(
     std::shared_ptr<SchemaRegistry const> registry,
     std::shared_ptr<simfil::StringPool const> strings);
 
-/** Attach a completion-only SchemaRegistry callback which materializes schema strings locally. */
+/** Attach a completion/compile-only SchemaRegistry callback which materializes schema strings locally. */
 void installCompletionSchemaRegistry(
     simfil::Environment& env,
     std::shared_ptr<SchemaRegistry const> registry,

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -309,7 +309,12 @@ struct TileFeatureLayer::Impl {
         std::shared_ptr<simfil::StringPool> stringPool,
         std::shared_ptr<LayerInfo> const& layerInfo)
         : schemaRegistry_(layerInfo ? layerInfo->schemaRegistry() : nullptr),
-          expressionCache_(makeSchemaAwareEnvironment(std::move(stringPool), schemaRegistry_))
+          expressionCache_(
+              makeSchemaAwareEnvironment(std::move(stringPool), schemaRegistry_),
+              [this]() {
+                  auto compileStrings = std::make_shared<simfil::StringPool>(*expressionCache_.environment().strings());
+                  return makeSchemaAwareCompletionEnvironment(std::move(compileStrings), schemaRegistry_);
+              })
     {
     }
 
@@ -1379,7 +1384,11 @@ TileFeatureLayer::evaluate(std::string_view query, bool anyMode, bool autoWildca
 tl::expected<std::vector<simfil::Diagnostics::Message>, simfil::Error>
 TileFeatureLayer::collectQueryDiagnostics(std::string_view query, const simfil::Diagnostics& diag, bool anyMode)
 {
-    return impl_->expressionCache_.diagnostics(query, diag, anyMode);
+    auto rootResult = root(0);
+    auto rootSchema = rootResult && *rootResult
+        ? (*rootResult)->schema()
+        : simfil::NoSchemaId;
+    return impl_->expressionCache_.diagnostics(query, diag, anyMode, rootSchema);
 }
 
 tl::expected<std::vector<simfil::CompletionCandidate>, simfil::Error>

--- a/libs/model/src/schemaregistry.cpp
+++ b/libs/model/src/schemaregistry.cpp
@@ -162,6 +162,28 @@ std::string_view kindMemoSuffix(std::optional<Kind> kind)
     return "n";
 }
 
+/** Build a memo key that keeps x-mapget context-sensitive aliases distinct. */
+std::string contextMemoKey(
+    std::string_view pointer,
+    std::optional<Kind> kind,
+    BuildContext const& context)
+{
+    auto appendSized = [](std::string& result, std::string_view value) {
+        result += std::to_string(value.size());
+        result += ':';
+        result += value;
+    };
+
+    std::string result(pointer);
+    result += '|';
+    result += kindMemoSuffix(kind);
+    result += '|';
+    appendSized(result, context.featureType_);
+    result += '|';
+    appendSized(result, context.attributeLayerName_);
+    return result;
+}
+
 /** Return whether a oneOf object/array wrapper represents a mapget multimap view. */
 bool isMapgetMultimap(nlohmann::json const& schema)
 {
@@ -259,6 +281,10 @@ struct SchemaRegistry::Impl
         std::vector<simfil::SchemaId> elementSchemas_;
         std::vector<std::string> flatFields_;
         std::vector<std::string> flatEnumSymbols_;
+        std::vector<AttributePathOwner> attributeOwners_;
+        std::string attributeTypeCode_;
+        std::string attributeType_;
+        std::string zserioType_;
         bool finalized_ = false;
     };
 
@@ -282,6 +308,16 @@ struct SchemaRegistry::Impl
         return valid(id) ? schemas_[id].kind_ : Kind::Object;
     }
 
+    [[nodiscard]] std::string_view metaType(simfil::SchemaId id) const
+    {
+        return valid(id) ? entriesById_[id].metaType_ : std::string_view{};
+    }
+
+    [[nodiscard]] std::string_view attributeTypeCode(simfil::SchemaId id) const
+    {
+        return valid(id) ? schemas_[id].attributeTypeCode_ : std::string_view{};
+    }
+
     simfil::SchemaId allocate(Kind kind, std::string key, std::string pointer, std::string metaType)
     {
         if (schemas_.size() > simfil::MaxSchemaId) {
@@ -299,6 +335,124 @@ struct SchemaRegistry::Impl
         registerKey(key, id);
         registerKey(pointer, id);
         return id;
+    }
+
+    void registerAttributeOwner(simfil::SchemaId id, AttributePathOwner owner)
+    {
+        if (!valid(id) ||
+            owner.featureType_.empty() ||
+            owner.attributeLayerName_.empty() ||
+            owner.attributeName_.empty()) {
+            return;
+        }
+
+        owner.attributeSchema_ = id;
+        auto& owners = schemas_[id].attributeOwners_;
+        auto duplicate = std::ranges::find_if(owners, [&](auto const& existing) {
+            return existing.featureType_ == owner.featureType_ &&
+                   existing.attributeLayerName_ == owner.attributeLayerName_ &&
+                   existing.attributeName_ == owner.attributeName_;
+        });
+        if (duplicate == owners.end()) {
+            owners.push_back(std::move(owner));
+        }
+    }
+
+    void registerSchemaMetadata(
+        simfil::SchemaId id,
+        nlohmann::json const& schema,
+        BuildContext const& context,
+        std::string_view metaType)
+    {
+        if (!valid(id)) {
+            return;
+        }
+
+        auto const* metadata = mapgetMetadata(schema);
+        auto zserioType = metadataString(metadata, "zserioType");
+        if (!zserioType.empty()) {
+            schemas_[id].zserioType_ = std::move(zserioType);
+        }
+
+        if (metaType != "Attribute") {
+            return;
+        }
+
+        auto attributeName = metadataString(metadata, "attributeTypeCode");
+        schemas_[id].attributeType_ = metadataString(metadata, "attributeType");
+        schemas_[id].attributeTypeCode_ = attributeName;
+        registerAttributeOwner(
+            id,
+            AttributePathOwner{
+                context.featureType_,
+                context.attributeLayerName_,
+                std::move(attributeName),
+                id});
+    }
+
+    [[nodiscard]] std::optional<AttributePathOwner> uniqueAttributeOwner(
+        simfil::SchemaId id,
+        std::string_view featureType) const
+    {
+        if (!valid(id)) {
+            return std::nullopt;
+        }
+
+        std::optional<AttributePathOwner> result;
+        for (auto const& owner : schemas_[id].attributeOwners_) {
+            if (owner.featureType_ != featureType) {
+                continue;
+            }
+            if (result) {
+                return std::nullopt;
+            }
+            result = owner;
+        }
+        return result;
+    }
+
+    [[nodiscard]] std::vector<std::string> constantTypeNames(
+        simfil::SchemaId id,
+        std::string_view symbolName) const
+    {
+        std::vector<std::string> result;
+        std::vector<simfil::SchemaId> visited;
+        collectConstantTypeNames(id, symbolName, visited, result);
+        std::ranges::sort(result);
+        auto duplicates = std::ranges::unique(result);
+        result.erase(duplicates.begin(), duplicates.end());
+        return result;
+    }
+
+    void collectConstantTypeNames(
+        simfil::SchemaId id,
+        std::string_view symbolName,
+        std::vector<simfil::SchemaId>& visited,
+        std::vector<std::string>& result) const
+    {
+        if (!valid(id) || std::ranges::find(visited, id) != visited.end()) {
+            return;
+        }
+        visited.push_back(id);
+
+        auto const& schema = schemas_[id];
+        if (schema.attributeTypeCode_ == symbolName && !schema.attributeType_.empty()) {
+            result.push_back(schema.attributeType_);
+        }
+        auto const hasDirectEnumSymbol =
+            std::ranges::find(schema.directEnumSymbols_, symbolName) != schema.directEnumSymbols_.end();
+        if (!schema.zserioType_.empty() && hasDirectEnumSymbol) {
+            result.push_back(schema.zserioType_);
+        }
+
+        for (auto const& [_, children] : schema.childSchemas_) {
+            for (auto child : children) {
+                collectConstantTypeNames(child, symbolName, visited, result);
+            }
+        }
+        for (auto child : schema.elementSchemas_) {
+            collectConstantTypeNames(child, symbolName, visited, result);
+        }
     }
 
     void registerKey(std::string const& key, simfil::SchemaId id)
@@ -609,9 +763,10 @@ private:
         }
 
         auto const key = annotatedKey(schema, pointer, context);
-        auto const memoKey = pointer + "|" + std::string(kindMemoSuffix(preferredKind));
+        auto const memoKey = contextMemoKey(pointer, preferredKind, context);
         if (auto memoIt = memo_.find(memoKey); memoIt != memo_.end()) {
             registry_.registerKey(key, memoIt->second);
+            registry_.registerSchemaMetadata(memoIt->second, schema, context, metaType);
             return memoIt->second;
         }
 
@@ -625,7 +780,7 @@ private:
             return buildArray(schema, std::move(pointer), std::move(context), std::move(key), std::move(metaType), memoKey);
         }
         if (isValueSchema(schema) && (!preferredKind || *preferredKind == Kind::Value)) {
-            return buildValue(schema, std::move(pointer), std::move(key), std::move(metaType), memoKey);
+            return buildValue(schema, std::move(pointer), std::move(context), std::move(key), std::move(metaType), memoKey);
         }
         return simfil::NoSchemaId;
     }
@@ -682,6 +837,11 @@ private:
         registry_.registerKey(pointer, selected);
         auto key = annotatedKey(schema, pointer, context);
         registry_.registerKey(key, selected);
+        registry_.registerSchemaMetadata(
+            selected,
+            schema,
+            context,
+            metadataString(mapgetMetadata(schema), "metaType"));
     }
 
     simfil::SchemaId buildObject(
@@ -697,6 +857,7 @@ private:
             std::move(key),
             pointer,
             metaType);
+        registry_.registerSchemaMetadata(id, schema, context, metaType);
         memo_[memoKey] = id;
 
         auto propertiesIt = schema.find("properties");
@@ -748,7 +909,8 @@ private:
             Kind::Array,
             std::move(key),
             pointer,
-            std::move(metaType));
+            metaType);
+        registry_.registerSchemaMetadata(id, schema, context, metaType);
         memo_[memoKey] = id;
 
         auto itemsIt = schema.find("items");
@@ -766,6 +928,7 @@ private:
     simfil::SchemaId buildValue(
         nlohmann::json const& schema,
         std::string pointer,
+        BuildContext context,
         std::string key,
         std::string metaType,
         std::string const& memoKey)
@@ -774,7 +937,8 @@ private:
             Kind::Value,
             std::move(key),
             std::move(pointer),
-            std::move(metaType));
+            metaType);
+        registry_.registerSchemaMetadata(id, schema, context, metaType);
         memo_[memoKey] = id;
 
         auto symbols = stringEnumSymbols(schema);
@@ -1003,6 +1167,13 @@ std::span<const std::string> SchemaRegistry::directEnumSymbols(simfil::SchemaId 
     return impl_->directEnumSymbols(schemaId);
 }
 
+std::vector<std::string> SchemaRegistry::constantTypeNames(
+    simfil::SchemaId schemaId,
+    std::string_view symbolName) const
+{
+    return impl_->constantTypeNames(schemaId, symbolName);
+}
+
 void SchemaRegistry::forEachDirectField(
     simfil::SchemaId schemaId,
     const std::function<void(std::string_view, std::span<const simfil::SchemaId>)>& fn) const
@@ -1038,6 +1209,94 @@ simfil::SchemaId SchemaRegistry::childSchema(
     std::optional<simfil::Schema::Kind> preferredKind) const
 {
     return impl_->childSchema(parent, fieldName, preferredKind);
+}
+
+SchemaRegistry::PathOwner SchemaRegistry::ownerForPath(
+    std::string_view featureType,
+    simfil::SchemaId rootSchema,
+    std::span<const std::string> fieldPath) const
+{
+    auto currentSchema = rootSchema;
+    if (!impl_->valid(currentSchema)) {
+        return {};
+    }
+
+    auto attributeOwner = impl_->uniqueAttributeOwner(rootSchema, featureType);
+    auto currentLayerName = std::optional<std::string>{};
+    auto enteredAttributeBranch =
+        impl_->metaType(rootSchema) == "AttributeLayerMap" ||
+        impl_->metaType(rootSchema) == "AttributeContainer" ||
+        impl_->metaType(rootSchema) == "Attribute";
+
+    for (auto const& fieldName : fieldPath) {
+        if (fieldName.empty()) {
+            continue;
+        }
+
+        auto const parentSchema = currentSchema;
+        auto const parentMetaType = impl_->metaType(parentSchema);
+        auto pendingAttributeName = std::optional<std::string>{};
+
+        if (parentMetaType == "AttributeLayerMap") {
+            // This edge selects the concrete attribute layer, but not yet a
+            // concrete attribute within that layer.
+            enteredAttributeBranch = true;
+            currentLayerName = fieldName;
+        }
+        else if (parentMetaType == "AttributeContainer") {
+            // This edge selects the attribute object inside the active layer.
+            enteredAttributeBranch = true;
+            pendingAttributeName = fieldName;
+        }
+
+        currentSchema = impl_->childSchema(currentSchema, fieldName, std::nullopt);
+        if (currentSchema == simfil::NoSchemaId) {
+            return {};
+        }
+
+        auto const currentMetaType = impl_->metaType(currentSchema);
+        if (currentMetaType == "AttributeLayerMap" || currentMetaType == "AttributeContainer") {
+            enteredAttributeBranch = true;
+        }
+        if (currentMetaType == "Attribute") {
+            enteredAttributeBranch = true;
+            if (auto owner = impl_->uniqueAttributeOwner(currentSchema, featureType)) {
+                attributeOwner = *owner;
+                continue;
+            }
+
+            // If the schema id is intentionally shared, the path edge still
+            // contains enough context to identify the selected attribute.
+            auto attributeName = std::string(impl_->attributeTypeCode(currentSchema));
+            if (attributeName.empty() && pendingAttributeName) {
+                attributeName = *pendingAttributeName;
+            }
+            if (currentLayerName && !attributeName.empty()) {
+                attributeOwner = AttributePathOwner{
+                    std::string(featureType),
+                    *currentLayerName,
+                    std::move(attributeName),
+                    currentSchema};
+            }
+        }
+        else if (auto owner = impl_->uniqueAttributeOwner(currentSchema, featureType)) {
+            attributeOwner = *owner;
+        }
+    }
+
+    if (attributeOwner) {
+        return {PathOwnerKind::Attribute, *attributeOwner};
+    }
+
+    if (enteredAttributeBranch) {
+        return {};
+    }
+
+    if (rootSchema == featureSchema(featureType) || rootSchema == featurePropertiesSchema(featureType)) {
+        return {PathOwnerKind::Feature, {}};
+    }
+
+    return {};
 }
 
 void installSchemaRegistry(

--- a/libs/model/src/schemaregistry.cpp
+++ b/libs/model/src/schemaregistry.cpp
@@ -475,6 +475,45 @@ struct SchemaRegistry::Impl
         return schemas_[id].flatEnumSymbols_;
     }
 
+    [[nodiscard]] std::span<const std::string> directEnumSymbols(simfil::SchemaId id) const
+    {
+        if (!valid(id)) {
+            return {};
+        }
+        return schemas_[id].directEnumSymbols_;
+    }
+
+    void forEachDirectField(
+        simfil::SchemaId id,
+        const std::function<void(std::string_view, std::span<const simfil::SchemaId>)>& fn) const
+    {
+        if (!valid(id)) {
+            return;
+        }
+
+        auto const& schema = schemas_[id];
+        for (auto const& fieldName : schema.directFields_) {
+            auto childIt = schema.childSchemas_.find(fieldName);
+            if (childIt == schema.childSchemas_.end()) {
+                fn(fieldName, {});
+            }
+            else {
+                fn(fieldName, childIt->second);
+            }
+        }
+    }
+
+    void forEachElementSchema(simfil::SchemaId id, const std::function<void(simfil::SchemaId)>& fn) const
+    {
+        if (!valid(id)) {
+            return;
+        }
+
+        for (auto childSchemaId : schemas_[id].elementSchemas_) {
+            fn(childSchemaId);
+        }
+    }
+
     [[nodiscard]] simfil::SchemaId childSchema(
         simfil::SchemaId parent,
         std::string_view fieldName,
@@ -809,7 +848,39 @@ public:
         return nestedEnumSymbols_;
     }
 
+    /** Return direct schema enum symbols when this adapter was built for completion/compile. */
+    auto directEnumSymbols() const& -> std::span<const simfil::StringId> override
+    {
+        return directEnumSymbols_;
+    }
+
 private:
+    /** Visit direct fields using ids from the completion/compile-local pool. */
+    auto forEachDirectField(
+        const std::function<void(simfil::StringId, std::span<const simfil::SchemaId>)>& fn) const -> void override
+    {
+        if (!registry_ || !strings_) {
+            return;
+        }
+
+        auto mutableStrings = std::const_pointer_cast<simfil::StringPool>(strings_);
+        registry_->forEachDirectField(id_, [&](std::string_view fieldName, std::span<const simfil::SchemaId> schemas) {
+            auto fieldId = mutableStrings->get(fieldName);
+            if (fieldId != simfil::StringPool::Empty) {
+                fn(fieldId, schemas);
+            }
+        });
+    }
+
+    /** Visit possible array element schemas. */
+    auto forEachElementSchema(const std::function<void(simfil::SchemaId)>& fn) const -> void override
+    {
+        if (!registry_) {
+            return;
+        }
+        registry_->forEachElementSchema(id_, fn);
+    }
+
     /** Insert schema-owned strings into the completion-local pool. */
     auto materializeStringIds(std::shared_ptr<simfil::StringPool> const& strings) -> void
     {
@@ -820,6 +891,7 @@ private:
         materialize(registry_->directFields(id_), *strings, directFields_);
         materialize(registry_->nestedFields(id_), *strings, nestedFields_);
         materialize(registry_->nestedEnumSymbols(id_), *strings, nestedEnumSymbols_);
+        materialize(registry_->directEnumSymbols(id_), *strings, directEnumSymbols_);
     }
 
     /** Convert schema-owned strings into StringIds in the provided temporary pool. */
@@ -850,6 +922,7 @@ private:
     std::vector<simfil::StringId> directFields_;
     std::vector<simfil::StringId> nestedFields_;
     std::vector<simfil::StringId> nestedEnumSymbols_;
+    std::vector<simfil::StringId> directEnumSymbols_;
 };
 
 } // namespace
@@ -923,6 +996,25 @@ std::span<const std::string> SchemaRegistry::nestedFields(simfil::SchemaId schem
 std::span<const std::string> SchemaRegistry::nestedEnumSymbols(simfil::SchemaId schemaId) const
 {
     return impl_->nestedEnumSymbols(schemaId);
+}
+
+std::span<const std::string> SchemaRegistry::directEnumSymbols(simfil::SchemaId schemaId) const
+{
+    return impl_->directEnumSymbols(schemaId);
+}
+
+void SchemaRegistry::forEachDirectField(
+    simfil::SchemaId schemaId,
+    const std::function<void(std::string_view, std::span<const simfil::SchemaId>)>& fn) const
+{
+    impl_->forEachDirectField(schemaId, fn);
+}
+
+void SchemaRegistry::forEachElementSchema(
+    simfil::SchemaId schemaId,
+    const std::function<void(simfil::SchemaId)>& fn) const
+{
+    impl_->forEachElementSchema(schemaId, fn);
 }
 
 simfil::SchemaId SchemaRegistry::featureSchema(std::string_view featureType) const

--- a/libs/model/src/simfilexpressioncache.h
+++ b/libs/model/src/simfilexpressioncache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <compare>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -25,31 +26,61 @@ namespace mapget
  * for a given node identifier.
  */
 using StringPoolResolveFun = std::function<std::shared_ptr<simfil::StringPool>(std::string_view const&)>;
+using CompileEnvironmentFactory = std::function<std::unique_ptr<simfil::Environment>()>;
 
 /**
  * Simfil compiled expression cache.
  */
 struct SimfilExpressionCache
 {
-    explicit SimfilExpressionCache(std::unique_ptr<simfil::Environment> env)
+    explicit SimfilExpressionCache(
+        std::unique_ptr<simfil::Environment> env,
+        CompileEnvironmentFactory compileEnvironmentFactory = {})
         : env_(std::move(env))
+        , compileEnvironmentFactory_(std::move(compileEnvironmentFactory))
     {}
 
-    auto eval(std::string_view query, bool anyMode, bool autoWildcard, std::function<tl::expected<TileFeatureLayer::QueryResult, simfil::Error>(const simfil::AST&)> evalFun) -> tl::expected<TileFeatureLayer::QueryResult, simfil::Error>
+    struct CacheKey
     {
+        std::string query;
+        bool anyMode = true;
+        bool autoWildcard = true;
+        simfil::SchemaId rootSchema = simfil::NoSchemaId;
+
+        auto operator<=>(CacheKey const&) const = default;
+    };
+
+    auto eval(
+        std::string_view query,
+        bool anyMode,
+        bool autoWildcard,
+        simfil::SchemaId rootSchema,
+        std::function<tl::expected<TileFeatureLayer::QueryResult, simfil::Error>(const simfil::AST&)> evalFun)
+        -> tl::expected<TileFeatureLayer::QueryResult, simfil::Error>
+    {
+        auto key = CacheKey{std::string(query), anyMode, autoWildcard, rootSchema};
+
         std::shared_lock s(mtx_);
-        auto iter = cache_.find(query);
+        auto iter = cache_.find(key);
         if (iter != cache_.end())
             return evalFun(*iter->second);
         s.unlock();
 
         std::unique_lock u(mtx_);
-        auto ast = simfil::compile(*env_, query, anyMode, autoWildcard);
+        auto compileEnv = compileEnvironmentFactory_ ? compileEnvironmentFactory_() : nullptr;
+        auto& env = compileEnv ? *compileEnv : *env_;
+        auto ast = simfil::compile(
+            env,
+            query,
+            simfil::CompileOptions{
+                .any = anyMode,
+                .autoWildcard = autoWildcard,
+                .rootSchema = rootSchema});
         if (!ast)
             return tl::unexpected<simfil::Error>(std::move(ast.error()));
 
         auto [newIter, _] = cache_.emplace(
-            std::string(query),
+            std::move(key),
             std::move(*ast)
         );
         return evalFun(*newIter->second);
@@ -69,32 +100,50 @@ struct SimfilExpressionCache
             return r;
         };
 
-        return eval(query, anyMode, autoWildcard, evalFun);
+        return eval(query, anyMode, autoWildcard, node.schema(), evalFun);
     }
 
-    auto compile(std::string_view query, bool anyMode) -> tl::expected<std::reference_wrapper<const simfil::ASTPtr>, simfil::Error>
+    auto compile(
+        std::string_view query,
+        bool anyMode,
+        bool autoWildcard,
+        simfil::SchemaId rootSchema) -> tl::expected<std::reference_wrapper<const simfil::ASTPtr>, simfil::Error>
     {
+        auto key = CacheKey{std::string(query), anyMode, autoWildcard, rootSchema};
+
         std::shared_lock s(mtx_);
-        auto iter = cache_.find(query);
+        auto iter = cache_.find(key);
         if (iter != cache_.end())
             return iter->second;
         s.unlock();
 
         std::unique_lock u(mtx_);
-        auto ast = simfil::compile(*env_, query, anyMode, true);
+        auto compileEnv = compileEnvironmentFactory_ ? compileEnvironmentFactory_() : nullptr;
+        auto& env = compileEnv ? *compileEnv : *env_;
+        auto ast = simfil::compile(
+            env,
+            query,
+            simfil::CompileOptions{
+                .any = anyMode,
+                .autoWildcard = autoWildcard,
+                .rootSchema = rootSchema});
         if (!ast)
             return tl::unexpected<simfil::Error>(std::move(ast.error()));
 
         auto [newIter, _] = cache_.emplace(
-            std::string(query),
+            std::move(key),
             std::move(*ast)
         );
         return newIter->second;
     }
 
-    auto diagnostics(std::string_view query, const simfil::Diagnostics& diag, bool anyMode) -> tl::expected<std::vector<simfil::Diagnostics::Message>, simfil::Error>
+    auto diagnostics(
+        std::string_view query,
+        const simfil::Diagnostics& diag,
+        bool anyMode,
+        simfil::SchemaId rootSchema = simfil::NoSchemaId) -> tl::expected<std::vector<simfil::Diagnostics::Message>, simfil::Error>
     {
-        auto ast = compile(query, anyMode);
+        auto ast = compile(query, anyMode, true, rootSchema);
         if (!ast)
             return tl::unexpected<simfil::Error>(std::move(ast.error()));
 
@@ -119,8 +168,9 @@ struct SimfilExpressionCache
     }
 
     mutable std::shared_mutex mtx_;
-    std::map<std::string, simfil::ASTPtr, std::less<>> cache_;
+    std::map<CacheKey, simfil::ASTPtr> cache_;
     std::unique_ptr<simfil::Environment> env_;
+    CompileEnvironmentFactory compileEnvironmentFactory_;
 };
 
 }

--- a/test/unit/test-info.cpp
+++ b/test/unit/test-info.cpp
@@ -72,7 +72,8 @@ nlohmann::json schemaAnnotatedLayerInfoJson()
                         "featureType": "Carrier"
                     },
                     "properties": {
-                        "limits": {"$ref": "#/$defs/LimitsLayer"}
+                        "limits": {"$ref": "#/$defs/LimitsLayer"},
+                        "advisoryLimits": {"$ref": "#/$defs/LimitsLayer"}
                     }
                 },
                 "LimitsLayer": {
@@ -88,10 +89,17 @@ nlohmann::json schemaAnnotatedLayerInfoJson()
                     "type": "object",
                     "x-mapget": {
                         "metaType": "Attribute",
-                        "attributeTypeCode": "speed"
+                        "attributeTypeCode": "speed",
+                        "attributeType": "synthetic.SpeedAttributeType"
                     },
                     "properties": {
-                        "unit": {"type": "string", "enum": ["km/h", "mph"]},
+                        "unit": {
+                            "type": "string",
+                            "enum": ["km/h", "mph"],
+                            "x-mapget": {
+                                "zserioType": "synthetic.SpeedUnit"
+                            }
+                        },
                         "value": {"type": "number"}
                     }
                 },
@@ -288,6 +296,12 @@ TEST_CASE("LayerInfo builds SchemaRegistry from x-mapget annotations", "[DataSou
     REQUIRE(registry->canHaveEnumSymbol(carrierSchema->id_, "km/h"));
     REQUIRE(registry->canHaveEnumSymbol(unitId, "mph"));
     REQUIRE_FALSE(registry->canHaveEnumSymbol(carrierSchema->id_, "notAnEnum"));
+    REQUIRE(
+        registry->constantTypeNames(carrierSchema->id_, "km/h") ==
+        std::vector<std::string>{"synthetic.SpeedUnit"});
+    REQUIRE(
+        registry->constantTypeNames(carrierSchema->id_, "speed") ==
+        std::vector<std::string>{"synthetic.SpeedAttributeType"});
 
     auto strings = std::make_shared<StringPool>("SchemaRegistryEnums");
     auto carrierSymbol = strings->emplace("Carrier").value();
@@ -388,6 +402,94 @@ TEST_CASE("TileFeatureLayer auto-wildcard uses schema enum paths", "[DataSourceI
     REQUIRE(unrelatedString->values.size() == 1);
     REQUIRE(unrelatedString->values.front().isa(simfil::ValueType::Bool));
     REQUIRE_FALSE(unrelatedString->values.front().as<simfil::ValueType::Bool>());
+}
+
+TEST_CASE("SchemaRegistry classifies feature and attribute path owners", "[DataSourceInfo]")
+{
+    auto layerInfo = LayerInfo::fromJson(schemaAnnotatedLayerInfoJson());
+    auto registry = layerInfo->schemaRegistry();
+    REQUIRE(registry);
+
+    auto const featureSchema = registry->featureSchema("Carrier");
+    auto const typeIdPath = std::vector<std::string>{"typeId"};
+    auto const featureOwner = registry->ownerForPath(
+        "Carrier",
+        featureSchema,
+        typeIdPath);
+    REQUIRE(featureOwner.kind_ == SchemaRegistry::PathOwnerKind::Feature);
+
+    auto const displayNamePath = std::vector<std::string>{"properties", "displayName"};
+    auto const displayNameOwner = registry->ownerForPath(
+        "Carrier",
+        featureSchema,
+        displayNamePath);
+    REQUIRE(displayNameOwner.kind_ == SchemaRegistry::PathOwnerKind::Feature);
+
+    auto const layerMapPath = std::vector<std::string>{"properties", "layer"};
+    auto const layerMapOwner = registry->ownerForPath(
+        "Carrier",
+        featureSchema,
+        layerMapPath);
+    REQUIRE(layerMapOwner.kind_ == SchemaRegistry::PathOwnerKind::Unknown);
+
+    auto const attributeLayerPath = std::vector<std::string>{"properties", "layer", "limits"};
+    auto const attributeLayerOwner = registry->ownerForPath(
+        "Carrier",
+        featureSchema,
+        attributeLayerPath);
+    REQUIRE(attributeLayerOwner.kind_ == SchemaRegistry::PathOwnerKind::Unknown);
+
+    auto const speedUnitPath = std::vector<std::string>{"properties", "layer", "limits", "speed", "unit"};
+    auto const attributeOwner = registry->ownerForPath(
+        "Carrier",
+        featureSchema,
+        speedUnitPath);
+    REQUIRE(attributeOwner.kind_ == SchemaRegistry::PathOwnerKind::Attribute);
+    REQUIRE(attributeOwner.attribute_.featureType_ == "Carrier");
+    REQUIRE(attributeOwner.attribute_.attributeLayerName_ == "limits");
+    REQUIRE(attributeOwner.attribute_.attributeName_ == "speed");
+    REQUIRE(attributeOwner.attribute_.attributeSchema_ != simfil::NoSchemaId);
+
+    auto const advisorySpeedUnitPath = std::vector<std::string>{"properties", "layer", "advisoryLimits", "speed", "unit"};
+    auto const advisoryAttributeOwner = registry->ownerForPath(
+        "Carrier",
+        featureSchema,
+        advisorySpeedUnitPath);
+    REQUIRE(advisoryAttributeOwner.kind_ == SchemaRegistry::PathOwnerKind::Attribute);
+    REQUIRE(advisoryAttributeOwner.attribute_.attributeLayerName_ == "advisoryLimits");
+    REQUIRE(advisoryAttributeOwner.attribute_.attributeName_ == "speed");
+    REQUIRE(advisoryAttributeOwner.attribute_.attributeSchema_ != simfil::NoSchemaId);
+
+    auto const propertiesSchema = registry->featurePropertiesSchema("Carrier");
+    auto const propertiesRootAttributeOwner = registry->ownerForPath(
+        "Carrier",
+        propertiesSchema,
+        std::vector<std::string>{"layer", "limits", "speed", "value"});
+    REQUIRE(propertiesRootAttributeOwner.kind_ == SchemaRegistry::PathOwnerKind::Attribute);
+    REQUIRE(propertiesRootAttributeOwner.attribute_.attributeLayerName_ == "limits");
+
+    auto const speedSchema = attributeOwner.attribute_.attributeSchema_;
+    auto const valuePath = std::vector<std::string>{"value"};
+    auto const attributeRootOwner = registry->ownerForPath(
+        "Carrier",
+        speedSchema,
+        valuePath);
+    REQUIRE(attributeRootOwner.kind_ == SchemaRegistry::PathOwnerKind::Attribute);
+    REQUIRE(attributeRootOwner.attribute_.attributeName_ == "speed");
+
+    auto const invalidAttributeTailPath = std::vector<std::string>{"properties", "layer", "limits", "speed", "missing"};
+    auto const invalidAttributeTailOwner = registry->ownerForPath(
+        "Carrier",
+        featureSchema,
+        invalidAttributeTailPath);
+    REQUIRE(invalidAttributeTailOwner.kind_ == SchemaRegistry::PathOwnerKind::Unknown);
+
+    auto const invalidAttributeRootPath = std::vector<std::string>{"missing"};
+    auto const invalidAttributeRootOwner = registry->ownerForPath(
+        "Carrier",
+        speedSchema,
+        invalidAttributeRootPath);
+    REQUIRE(invalidAttributeRootOwner.kind_ == SchemaRegistry::PathOwnerKind::Unknown);
 }
 
 TEST_CASE("TileFeatureLayer exposes SchemaIds on feature-model nodes", "[DataSourceInfo]")

--- a/test/unit/test-info.cpp
+++ b/test/unit/test-info.cpp
@@ -359,6 +359,37 @@ TEST_CASE("TileFeatureLayer completes schema fields and enum symbols without mut
     REQUIRE(strings->get("km/h") == simfil::StringPool::Empty);
 }
 
+TEST_CASE("TileFeatureLayer auto-wildcard uses schema enum paths", "[DataSourceInfo]")
+{
+    auto layerInfo = LayerInfo::fromJson(schemaAnnotatedLayerInfoJson());
+    auto strings = std::make_shared<StringPool>("SchemaAutoWildcardNode");
+    auto tile = std::make_shared<TileFeatureLayer>(
+        TileId::fromWgs84(42., 11., 13),
+        "SchemaAutoWildcardNode",
+        "SchemaAutoWildcardMap",
+        layerInfo,
+        strings);
+
+    auto feature = tile->newFeature("Carrier", {{"carrierId", 7}});
+    auto attrs = feature->attributes();
+    REQUIRE(attrs->addField("displayName", "km/h").has_value());
+    auto layer = feature->attributeLayers()->newLayer("limits");
+    auto speed = layer->newAttribute("speed");
+    REQUIRE(speed->addField("unit", "mph").has_value());
+
+    auto matchingEnum = tile->evaluate("mph", *feature, false, true);
+    REQUIRE(matchingEnum);
+    REQUIRE(matchingEnum->values.size() == 1);
+    REQUIRE(matchingEnum->values.front().isa(simfil::ValueType::Bool));
+    REQUIRE(matchingEnum->values.front().as<simfil::ValueType::Bool>());
+
+    auto unrelatedString = tile->evaluate(R"("km/h")", *feature, false, true);
+    REQUIRE(unrelatedString);
+    REQUIRE(unrelatedString->values.size() == 1);
+    REQUIRE(unrelatedString->values.front().isa(simfil::ValueType::Bool));
+    REQUIRE_FALSE(unrelatedString->values.front().as<simfil::ValueType::Bool>());
+}
+
 TEST_CASE("TileFeatureLayer exposes SchemaIds on feature-model nodes", "[DataSourceInfo]")
 {
     auto layerInfo = LayerInfo::fromJson(schemaAnnotatedLayerInfoJson());


### PR DESCRIPTION
Wires schema-aware SIMFIL compilation into TileFeatureLayer query compilation and uses temporary schema string materialization for compile-time classification/path rewriting.\n\nDepends on: https://github.com/Klebert-Engineering/simfil/pull/149\n\nValidation:\n- ctest --test-dir /home/joseph/code/mapviewer/deps/mapget/build --output-on-failure