### PR TITLE
Release 2026.3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(mapget LANGUAGES CXX C)
 # Allow version to be set from command line for CI/CD
 # For local development, use the default version
 if(NOT DEFINED MAPGET_VERSION)
-  set(MAPGET_VERSION 2026.3.3)
+  set(MAPGET_VERSION 2026.3.4)
 endif()
 
 set(CMAKE_CXX_STANDARD 20)

--- a/libs/http-service/src/tiles-ws-controller.cpp
+++ b/libs/http-service/src/tiles-ws-controller.cpp
@@ -142,12 +142,19 @@ private:
 void registerTilesWebSocketController(drogon::HttpAppFramework& app, HttpService& service)
 {
     app.registerController(std::make_shared<TilesWebSocketController>(service));
-    app.registerHandler(
-        "/interactive/payload",
-        [](const drogon::HttpRequestPtr& req, std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
-            tilesWsHandleNextRequest(req, std::move(callback));
-        },
-        {drogon::Get, drogon::Post});
+    auto registerPayloadEndpoint = [&app](std::string const& path) {
+        app.registerHandler(
+            path,
+            [](const drogon::HttpRequestPtr& req, std::function<void(const drogon::HttpResponsePtr&)>&& callback) {
+                tilesWsHandleNextRequest(req, std::move(callback));
+            },
+            {drogon::Get, drogon::Post});
+    };
+
+    registerPayloadEndpoint("/interactive/payload");
+    // Keep the long-poll drain endpoint paired with the legacy `/tiles`
+    // websocket path for stale reverse-proxy configurations.
+    registerPayloadEndpoint("/tiles/next");
 }
 
 /** Return process-wide websocket metrics for `/status-data`. */

--- a/libs/model/include/mapget/model/attrlayer.h
+++ b/libs/model/include/mapget/model/attrlayer.h
@@ -4,6 +4,10 @@
 #include "attr.h"
 #include "merged-array-view.h"
 
+#include "nlohmann/json.hpp"
+
+#include <optional>
+
 namespace mapget
 {
 
@@ -22,8 +26,22 @@ class AttributeLayer : public simfil::BaseObject<TileFeatureLayer, Attribute>
     friend class bitsery::Access;
 
 public:
+    static constexpr std::string_view InstanceIdField = "id";
+
     using BaseObject::addField;
     using BaseObject::get;
+
+    /**
+     * Attach a numeric source-layer instance id to this attribute layer.
+     *
+     * AttributeLayerList may contain multiple entries with the same public
+     * layer name. The instance id lets GeoJSON/inspection users distinguish
+     * those otherwise identical layer objects without changing query/style
+     * paths such as `properties.layer.RoadRulesLayer`.
+     */
+    void setId(uint64_t id);
+    [[nodiscard]] std::optional<uint64_t> id() const;
+    [[nodiscard]] nlohmann::json toJson() const override;
 
     /**
      * Create a new attribute and immediately insert it into the layer.
@@ -115,6 +133,7 @@ public:
     /** Assign the object schema for the layer-name map stored by this view. */
     tl::expected<void, simfil::Error> setObjectSchema(simfil::SchemaId schemaId);
 
+    [[nodiscard]] nlohmann::json toJson() const override;
     [[nodiscard]] simfil::ValueType type() const override;
     [[nodiscard]] simfil::ModelNode::Ptr at(int64_t i) const override;
     [[nodiscard]] uint32_t size() const override;

--- a/libs/model/src/attrlayer.cpp
+++ b/libs/model/src/attrlayer.cpp
@@ -6,6 +6,77 @@
 namespace mapget
 {
 
+void AttributeLayer::setId(uint64_t id)
+{
+    auto value = model().newValue(static_cast<int64_t>(id));
+    auto replaced = false;
+    storage_->iterate(members_, [&](auto&& member) {
+        if (simfil::detail::objectFieldName(member) == StringPool::IdStr) {
+            simfil::detail::objectFieldNode(member) = value->addr();
+            replaced = true;
+            return false;
+        }
+        return true;
+    });
+    if (!replaced) {
+        storage_->emplace_back(members_, StringPool::IdStr, value->addr());
+    }
+}
+
+std::optional<uint64_t> AttributeLayer::id() const
+{
+    auto valueNode = get(StringPool::IdStr);
+    if (!valueNode) {
+        return {};
+    }
+
+    auto value = valueNode->value();
+    if (auto const* signedValue = std::get_if<int64_t>(&value)) {
+        if (*signedValue < 0) {
+            return {};
+        }
+        return static_cast<uint64_t>(*signedValue);
+    }
+    return {};
+}
+
+nlohmann::json AttributeLayer::toJson() const
+{
+    auto result = nlohmann::json::object();
+    auto isMultiMap = false;
+    if (auto layerId = id()) {
+        result[std::string{InstanceIdField}] = *layerId;
+    }
+
+    for (auto const& [fieldId, value] : fields()) {
+        auto fieldName = model().strings()->resolve(fieldId);
+        if (!fieldName) {
+            continue;
+        }
+        if (*fieldName == InstanceIdField) {
+            continue;
+        }
+
+        auto const fieldKey = std::string{*fieldName};
+        auto fieldValue = value->toJson();
+        if (result.contains(fieldKey)) {
+            isMultiMap = true;
+            if (!result[fieldKey].is_array()) {
+                result[fieldKey] = nlohmann::json::array({std::move(result[fieldKey])});
+            }
+            result[fieldKey].push_back(std::move(fieldValue));
+        }
+        else {
+            result[fieldKey] = std::move(fieldValue);
+        }
+    }
+
+    if (isMultiMap) {
+        result["_multimap"] = true;
+    }
+    return result;
+}
+
 AttributeLayer::AttributeLayer(
     simfil::ArrayIndex i,
     simfil::ModelConstPtr l,
@@ -48,6 +119,9 @@ bool AttributeLayer::forEachAttribute(const std::function<bool(const model_ptr<A
         return false;
     for (auto const& [_, value] : fields()) {
         if (value->addr().column() != TileFeatureLayer::ColumnId::Attributes) {
+            if (_ == StringPool::IdStr) {
+                continue;
+            }
             log().warn("Don't add anything other than Attributes into AttributeLayers!");
             continue;
         }
@@ -145,6 +219,33 @@ bool AttributeLayerList::forEachLayer(
         return ext->forEachLayer(cb);
     }
     return true;
+}
+
+nlohmann::json AttributeLayerList::toJson() const
+{
+    auto result = nlohmann::json::object();
+    auto isMultiMap = false;
+
+    forEachLayer([&](std::string_view layerName, model_ptr<AttributeLayer> const& layer) {
+        auto const layerKey = std::string{layerName};
+        auto layerValue = layer->toJson();
+        if (result.contains(layerKey)) {
+            isMultiMap = true;
+            if (!result[layerKey].is_array()) {
+                result[layerKey] = nlohmann::json::array({std::move(result[layerKey])});
+            }
+            result[layerKey].push_back(std::move(layerValue));
+        }
+        else {
+            result[layerKey] = std::move(layerValue);
+        }
+        return true;
+    });
+
+    if (isMultiMap) {
+        result["_multimap"] = true;
+    }
+    return result;
 }
 
 simfil::model_ptr<simfil::Object> AttributeLayerList::localObject() const

--- a/libs/model/src/feature.cpp
+++ b/libs/model/src/feature.cpp
@@ -540,6 +540,9 @@ nlohmann::json Feature::toJson() const
 {
     auto json = simfil::MandatoryDerivedModelNodeBase<TileFeatureLayer>::toJson();
     json.erase("lod");
+    if (auto layers = attributeLayersOrNull()) {
+        json["properties"]["layer"] = layers->toJson();
+    }
     return json;
 }
 

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -2364,6 +2364,13 @@ ModelNode::Ptr TileFeatureLayer::clone(
         newCacheNode = newNode;
         for (auto [key, value] : resolved->fields()) {
             if (auto keyStr = otherLayer->strings()->resolve(key)) {
+                if (*keyStr == AttributeLayer::InstanceIdField) {
+                    auto const idValue = value->value();
+                    if (auto const* signedId = std::get_if<int64_t>(&idValue); signedId && *signedId >= 0) {
+                        newNode->setId(static_cast<uint64_t>(*signedId));
+                    }
+                    continue;
+                }
                 auto cloned = clone(cache, otherLayer, value);
                 newNode->addField(*keyStr, resolve<Attribute>(*cloned));
             }

--- a/libs/model/src/geojson-import.cpp
+++ b/libs/model/src/geojson-import.cpp
@@ -911,6 +911,9 @@ void importAttributeObject(
     }
 
     for (auto const& [key, value] : json.items()) {
+        if (key == "_multimap") {
+            continue;
+        }
         if (key == "validity") {
             deferredValidities.push_back(DeferredAttributeValidity{hostFeature, attribute, value});
             continue;
@@ -924,6 +927,52 @@ void importAttributeObject(
         auto result = attribute->addField(key, importGenericNode(tile, value, hostFeature));
         if (!result) {
             raiseImport(result.error().message);
+        }
+    }
+}
+
+/** Import one attribute-layer object, preserving duplicate attribute names and optional instance id metadata. */
+void importAttributeLayerObject(
+    TileFeatureLayer& tile,
+    model_ptr<Feature> feature,
+    std::string const& layerName,
+    nlohmann::json const& layerJson,
+    GeoJsonImportOptions const& options,
+    std::vector<DeferredAttributeValidity>& deferredValidities)
+{
+    if (!layerJson.is_object()) {
+        raiseImport(fmt::format("Attribute layer '{}' must be a JSON object.", layerName));
+    }
+
+    auto attrLayer = feature->attributeLayers()->newLayer(layerName);
+    for (auto const& [attrName, attrValue] : layerJson.items()) {
+        if (attrName == "_multimap") {
+            continue;
+        }
+        if (attrName == AttributeLayer::InstanceIdField) {
+            if (!attrValue.is_number_unsigned() && !attrValue.is_number_integer()) {
+                raiseImport(fmt::format("Attribute layer '{}' id must be an integer.", layerName));
+            }
+            auto const layerId = attrValue.get<int64_t>();
+            if (layerId < 0) {
+                raiseImport(fmt::format("Attribute layer '{}' id must not be negative.", layerName));
+            }
+            attrLayer->setId(static_cast<uint64_t>(layerId));
+            continue;
+        }
+
+        auto importOneAttribute = [&](nlohmann::json const& attributeJson) {
+            auto attribute = attrLayer->newAttribute(attrName);
+            importAttributeObject(tile, feature, attribute, attributeJson, options, deferredValidities);
+        };
+
+        if (attrValue.is_array()) {
+            for (auto const& element : attrValue) {
+                importOneAttribute(element);
+            }
+        }
+        else {
+            importOneAttribute(attrValue);
         }
     }
 }
@@ -945,13 +994,16 @@ void importProperties(
             raiseImport("properties.layer must be a JSON object.");
         }
         for (auto const& [layerName, layerValue] : layerIt->items()) {
-            if (!layerValue.is_object()) {
-                raiseImport(fmt::format("Attribute layer '{}' must be a JSON object.", layerName));
+            if (layerName == "_multimap") {
+                continue;
             }
-            auto attrLayer = feature->attributeLayers()->newLayer(layerName);
-            for (auto const& [attrName, attrValue] : layerValue.items()) {
-                auto attribute = attrLayer->newAttribute(attrName);
-                importAttributeObject(tile, feature, attribute, attrValue, options, deferredValidities);
+            if (layerValue.is_array()) {
+                for (auto const& layerElement : layerValue) {
+                    importAttributeLayerObject(tile, feature, layerName, layerElement, options, deferredValidities);
+                }
+            }
+            else {
+                importAttributeLayerObject(tile, feature, layerName, layerValue, options, deferredValidities);
             }
         }
     }

--- a/test/unit/test-http-datasource.cpp
+++ b/test/unit/test-http-datasource.cpp
@@ -104,10 +104,15 @@ private:
 class WsTilesClient
 {
 public:
-    WsTilesClient(uint16_t port, std::shared_ptr<LayerInfo> layerInfo, bool requireFeatureLayer = true)
+    WsTilesClient(
+        uint16_t port,
+        std::shared_ptr<LayerInfo> layerInfo,
+        bool requireFeatureLayer = true,
+        std::string pullPath = "/interactive/payload")
         : pullClient_("127.0.0.1", port),
           layerInfo_(std::move(layerInfo)),
           requireFeatureLayer_(requireFeatureLayer),
+          pullPath_(std::move(pullPath)),
           reader_(
               [this](auto&&, auto&&) { return layerInfo_; },
               [this](auto&& tile) {
@@ -197,7 +202,8 @@ public:
                 const auto waitCapMs = allDone ? 100 : 1000;
                 const auto waitMs = std::clamp<int64_t>(remainingMs, 1, waitCapMs);
                 const auto [result, resp] = pullClient_.get(fmt::format(
-                    "/interactive/payload?clientId={}&waitMs={}&maxBytes={}",
+                    "{}?clientId={}&waitMs={}&maxBytes={}",
+                    pullPath_,
                     clientId,
                     waitMs,
                     64 * 1024 * 1024));
@@ -228,7 +234,7 @@ public:
                     return true;
                 }
                 else {
-                    setError(fmt::format("Unexpected /interactive/payload response status: {}", static_cast<int>(resp->statusCode())));
+                    setError(fmt::format("Unexpected {} response status: {}", pullPath_, static_cast<int>(resp->statusCode())));
                     return true;
                 }
 
@@ -362,6 +368,7 @@ private:
     SyncHttpClient pullClient_;
     std::shared_ptr<LayerInfo> layerInfo_;
     bool requireFeatureLayer_{true};
+    std::string pullPath_;
     TileLayerStream::Reader reader_;
 };
 
@@ -808,8 +815,12 @@ TEST_CASE("HttpDataSource", "[HttpDataSource]")
                 return conn;
             };
 
-            auto runWsTilesRequestAtPath = [&](std::string_view path, bool sendAuthHeader, const std::string& requestJson) {
-                WsTilesClient wsClient(service.port(), layerInfo);
+            auto runWsTilesRequestAtPath = [&](
+                std::string_view path,
+                bool sendAuthHeader,
+                const std::string& requestJson,
+                std::string pullPath = "/interactive/payload") {
+                WsTilesClient wsClient(service.port(), layerInfo, true, std::move(pullPath));
 
                 REQUIRE(wsClient.connect(sendAuthHeader, path));
                 requireConnected(wsClient)->send(requestJson, drogon::WebSocketMessageType::Text);
@@ -841,7 +852,7 @@ TEST_CASE("HttpDataSource", "[HttpDataSource]")
                     })})},
                 }).dump();
 
-                auto [status, wsTileCount] = runWsTilesRequestAtPath("/tiles", true, req);
+                auto [status, wsTileCount] = runWsTilesRequestAtPath("/tiles", true, req, "/tiles/next");
                 REQUIRE(wsTileCount == 1);
                 REQUIRE(status["requests"].size() == 1);
                 REQUIRE(status["requests"][0]["status"].get<int>() ==

--- a/test/unit/test-model.cpp
+++ b/test/unit/test-model.cpp
@@ -583,6 +583,86 @@ TEST_CASE("FeatureLayer", "[test.featurelayer]")
     }
 }
 
+TEST_CASE("AttributeLayer duplicate names retain instance identity in GeoJSON", "[test.featurelayer]")
+{
+    auto layerInfo = LayerInfo::fromJson(R"({
+        "layerId": "Road",
+        "type": "Features",
+        "featureTypes": [
+            {
+                "name": "Road",
+                "uniqueIdCompositions": [
+                    [
+                        {
+                            "partId": "roadId",
+                            "description": "Synthetic road id.",
+                            "datatype": "U32"
+                        }
+                    ]
+                ]
+            }
+        ]
+    })"_json);
+    auto strings = std::make_shared<StringPool>("test-node");
+    auto tile = std::make_shared<TileFeatureLayer>(
+        TileId::fromValue(545555028),
+        "test-node",
+        "TestMap",
+        layerInfo,
+        strings);
+
+    auto road = tile->newFeature("Road", {{"roadId", 1}});
+    auto firstRulesLayer = tile->newAttributeLayer();
+    firstRulesLayer->setId(3);
+    auto firstSpeedA = firstRulesLayer->newAttribute("SPEED_LIMIT");
+    REQUIRE(firstSpeedA->addField("value", int64_t{50}).has_value());
+    auto firstSpeedB = firstRulesLayer->newAttribute("SPEED_LIMIT");
+    REQUIRE(firstSpeedB->addField("value", int64_t{80}).has_value());
+
+    auto secondRulesLayer = tile->newAttributeLayer();
+    secondRulesLayer->setId(4);
+    auto secondSpeedA = secondRulesLayer->newAttribute("SPEED_LIMIT");
+    REQUIRE(secondSpeedA->addField("value", int64_t{30}).has_value());
+    auto secondSpeedB = secondRulesLayer->newAttribute("SPEED_LIMIT");
+    REQUIRE(secondSpeedB->addField("value", int64_t{60}).has_value());
+
+    auto layers = road->attributeLayers();
+    layers->addLayer("RoadRulesLayer", firstRulesLayer);
+    layers->addLayer("RoadRulesLayer", secondRulesLayer);
+
+    auto json = road->toJson();
+    auto const& layerMap = json.at("properties").at("layer");
+    REQUIRE(layerMap.at("_multimap") == true);
+    REQUIRE(layerMap.at("RoadRulesLayer").is_array());
+    REQUIRE(layerMap.at("RoadRulesLayer").size() == 2);
+
+    auto const& firstJson = layerMap.at("RoadRulesLayer")[0];
+    REQUIRE(firstJson.at("id") == 3);
+    REQUIRE(firstJson.at("_multimap") == true);
+    REQUIRE(firstJson.at("SPEED_LIMIT").is_array());
+    REQUIRE(firstJson.at("SPEED_LIMIT")[0].at("value") == 50);
+    REQUIRE(firstJson.at("SPEED_LIMIT")[1].at("value") == 80);
+
+    auto const& secondJson = layerMap.at("RoadRulesLayer")[1];
+    REQUIRE(secondJson.at("id") == 4);
+    REQUIRE(secondJson.at("_multimap") == true);
+    REQUIRE(secondJson.at("SPEED_LIMIT").is_array());
+    REQUIRE(secondJson.at("SPEED_LIMIT")[0].at("value") == 30);
+    REQUIRE(secondJson.at("SPEED_LIMIT")[1].at("value") == 60);
+
+    auto collected = collectLayerAttributeValues(layers);
+    REQUIRE(collected.size() == 4);
+
+    auto imported = std::make_shared<TileFeatureLayer>(
+        TileId::fromValue(545555028),
+        "test-node-import",
+        "TestMap",
+        layerInfo,
+        std::make_shared<StringPool>("test-node-import"));
+    REQUIRE_NOTHROW(imported->fromJson(tile->toJson()));
+    REQUIRE(imported->toJson() == tile->toJson());
+}
+
 TEST_CASE("FeatureLayer stores geometry source-data refs compactly for singleton geometries",
           "[test.featurelayer][test.featurelayer.sourcedatarefs]")
 {


### PR DESCRIPTION
Release branch for 2026.3.4.
Includes:
- Restore legacy /tiles/next payload endpoint alias.
- Preserve attribute layer instance IDs in GeoJSON import/export.