### PR TITLE
Fix legacy TileId coordinate conversion

### DIFF
--- a/libs/model/include/mapget/model/tileid.h
+++ b/libs/model/include/mapget/model/tileid.h
@@ -35,7 +35,10 @@ inline bool isLegacyTileId(int64_t value)
 
 /**
  * Convert a removed mapget `0xXXXXYYYYZZZZ` tile ID to the canonical packed
- * representation. This is migration glue for legacy manifests/keys only.
+ * representation. Legacy columns start at the antimeridian and rows at the
+ * north pole, while packed coordinates follow signed NDS coordinates in
+ * two's-complement Morton order. This is migration glue for legacy
+ * manifests/keys only.
  */
 inline TileId legacyTileIdToPacked(int64_t value)
 {
@@ -46,7 +49,14 @@ inline TileId legacyTileIdToPacked(int64_t value)
     auto const level = static_cast<int>(raw & 0xFFFFU);
     auto const x = static_cast<uint32_t>((raw >> 32U) & 0xFFFFU);
     auto const y = static_cast<uint32_t>((raw >> 16U) & 0xFFFFU);
-    return TileId::fromTileXY(x, y, level);
+
+    auto const columnCount = uint32_t{1} << (level + 1U);
+    auto const rowCount = uint32_t{1} << level;
+    // Move the legacy antimeridian origin to signed NDS coordinate zero.
+    auto const packedX = (x + columnCount / 2U) % columnCount;
+    // Flip the north-origin row, then rotate it into signed NDS grid order.
+    auto const packedY = (rowCount + rowCount / 2U - 1U - y) % rowCount;
+    return TileId::fromTileXY(packedX, packedY, level);
 }
 
 } // namespace mapget

--- a/test/unit/test-geojsonsource.cpp
+++ b/test/unit/test-geojsonsource.cpp
@@ -17,8 +17,8 @@ namespace
 // Sample GeoJSON with signed packed tile IDs, including a negative level-15 value.
 constexpr int32_t largeTileId = -2147483648;
 constexpr int32_t secondTileId = -2147483647;
-constexpr int64_t legacyMapgetTileId = (int64_t{1} << 32) | int64_t{1};
-constexpr int32_t legacyMapgetTileIdPacked = 131073;
+// Fixed legacy mapget tile covering Germany.
+constexpr int64_t legacyMapgetTileId = 0x21fa0777000d;
 
 auto sampleGeoJson = R"json({"type": "FeatureCollection", "features": [{
     "geometry": {
@@ -280,7 +280,7 @@ TEST_CASE("GeoJsonSource", "[GeoJsonSource]")
 
         REQUIRE(source.hasManifest());
         REQUIRE(source.manifest().files.size() == 1);
-        REQUIRE(source.manifest().files[0].tileId == legacyMapgetTileIdPacked);
+        REQUIRE(source.manifest().files[0].tileId == TileId::fromTileXY(0x01fa, 0x0888, 13).value());
 
         auto info = source.info();
         auto layer = info.getLayer("GeoJsonAny");
@@ -288,7 +288,7 @@ TEST_CASE("GeoJsonSource", "[GeoJsonSource]")
 
         auto strings = std::make_shared<StringPool>(info.nodeId_);
         auto tile = std::make_shared<TileFeatureLayer>(
-            TileId::fromTileXY(1, 0, 1),
+            TileId::fromTileXY(0x01fa, 0x0888, 13),
             info.nodeId_,
             info.mapId_,
             layer,
@@ -321,7 +321,7 @@ TEST_CASE("GeoJsonSource", "[GeoJsonSource]")
 
         REQUIRE(source.hasManifest());
         REQUIRE(source.manifest().files.size() == 1);
-        REQUIRE(source.manifest().files[0].tileId == TileId::fromTileXY(0, 0, 13).value());
+        REQUIRE(source.manifest().files[0].tileId == TileId::fromTileXY(8192, 4095, 13).value());
 
         std::filesystem::remove_all(tempDir);
     }
@@ -420,11 +420,11 @@ TEST_CASE("GeoJsonSource", "[GeoJsonSource]")
         auto layer = info.getLayer("GeoJsonAny");
         REQUIRE(layer != nullptr);
         REQUIRE(layer->coverage_.size() == 1);
-        REQUIRE(layer->coverage_.front().min_ == TileId::fromTileXY(1, 0, 1));
+        REQUIRE(layer->coverage_.front().min_ == TileId::fromTileXY(0x01fa, 0x0888, 13));
 
         auto strings = std::make_shared<StringPool>(info.nodeId_);
         auto tile = std::make_shared<TileFeatureLayer>(
-            TileId::fromTileXY(1, 0, 1),
+            TileId::fromTileXY(0x01fa, 0x0888, 13),
             info.nodeId_,
             info.mapId_,
             layer,

--- a/test/unit/test-info.cpp
+++ b/test/unit/test-info.cpp
@@ -213,13 +213,13 @@ TEST_CASE("MapTileKey accepts removed mapget tile-id layout", "[DataSourceInfo]"
 {
     auto const legacyTileId = (int64_t{1} << 32) | int64_t{1};
     auto const parsed = MapTileKey("Features:Map:Layer:" + std::to_string(legacyTileId) + ":0");
-    REQUIRE(parsed.tileId_ == TileId::fromTileXY(1, 0, 1));
+    REQUIRE(parsed.tileId_ == TileId::fromTileXY(3, 0, 1));
 }
 
 TEST_CASE("MapTileKey accepts removed hexadecimal mapget tile-id layout", "[DataSourceInfo]")
 {
     auto const parsed = MapTileKey("Features:Map:Layer:21fa0777000d:0");
-    REQUIRE(parsed.tileId_ == TileId::fromTileXY(0x21fa, 0x0777, 13));
+    REQUIRE(parsed.tileId_ == TileId::fromTileXY(0x01fa, 0x0888, 13));
 }
 
 TEST_CASE("MapTileKey keeps SourceData tile zero as metadata sentinel", "[DataSourceInfo]")

--- a/test/unit/test-model.cpp
+++ b/test/unit/test-model.cpp
@@ -1545,7 +1545,15 @@ TEST_CASE("TileId", "[TileId]") {
     SECTION("Legacy mapget tile-id migration helpers") {
         auto const legacy = (int64_t{1} << 32) | int64_t{1};
         REQUIRE(isLegacyTileId(legacy));
-        REQUIRE(legacyTileIdToPacked(legacy) == TileId::fromTileXY(1, 0, 1));
+        REQUIRE(legacyTileIdToPacked(legacy) == TileId::fromTileXY(3, 0, 1));
+
+        // This fixed legacy tile covers Germany and exercises both origin
+        // changes rather than merely producing a structurally valid tile.
+        constexpr int64_t legacyGermanyTile = 0x21fa0777000d;
+        REQUIRE(legacyTileIdToPacked(legacyGermanyTile) ==
+            TileId::fromTileXY(0x01fa, 0x0888, 13));
+        REQUIRE(legacyTileIdToPacked(legacyGermanyTile) ==
+            TileId::fromWgs84(11.13, 48.0, 13));
         REQUIRE_FALSE(isLegacyTileId(-1));
         REQUIRE_FALSE(isLegacyTileId((int64_t{1} << 32) | (int64_t{2} << 16) | int64_t{1}));
         REQUIRE_THROWS(legacyTileIdToPacked(-1));


### PR DESCRIPTION
## Summary

- convert both legacy mapget tile-grid axes into PackedTileId's signed NDS Morton coordinate order
- cover a known legacy Germany tile in the model and MapTileKey tests
- verify legacy GeoJSONFolder manifest and filename ingestion resolve to the correct packed tile

## Root cause

`legacyTileIdToPacked` passed the legacy X/Y grid coordinates directly to `PackedTileId::fromTileXY`. The legacy grid starts at the antimeridian and north pole, while PackedTileId grid coordinates are derived from signed NDS coordinates in two's-complement Morton order. The resulting tiles therefore landed in the wrong geographic region.

## Validation

- `cmake --build build --target test.mapget -- -j8`
- focused TileId, MapTileKey, and GeoJsonSource tests
- full 105-test suite; the two Python integration tests were rerun serially because parallel local ndslive-math wheel builds share a build directory
