### PR TITLE
Guard and harden mapget releases

### DIFF
--- a/.github/scripts/test_validate_version.py
+++ b/.github/scripts/test_validate_version.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Focused tests for mapget's release-version preflight."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from validate_version import (
+    ReleaseContext,
+    determine_release_context,
+    get_base_version,
+    get_cmake_version,
+    validate_versions,
+)
+
+
+class ValidateVersionTest(unittest.TestCase):
+    """Covers each CI event that introduces a release identity."""
+
+    def test_extracts_cmake_and_scm_base_versions(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cmake_file = Path(directory) / "CMakeLists.txt"
+            cmake_file.write_text(
+                "if(NOT DEFINED MAPGET_VERSION)\n"
+                "  set(MAPGET_VERSION 2026.3.5)\n"
+                "endif()\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(get_cmake_version(cmake_file), "2026.3.5")
+
+        self.assertEqual(get_base_version("2026.3.5.dev123"), "2026.3.5")
+
+    def test_tag_requires_cmake_and_scm_to_match(self):
+        context = determine_release_context(
+            {
+                "GITHUB_EVENT_NAME": "push",
+                "GITHUB_REF": "refs/tags/v2026.3.5",
+            }
+        )
+
+        self.assertEqual(
+            context,
+            ReleaseContext("2026.3.5", "Tagged release", require_scm_match=True),
+        )
+        self.assertEqual(validate_versions("2026.3.5", "2026.3.5", context), [])
+        self.assertEqual(len(validate_versions("2026.3.4", "2026.3.5", context)), 1)
+        self.assertEqual(len(validate_versions("2026.3.5", "2026.3.4", context)), 1)
+
+    def test_release_pr_requires_branch_and_cmake_to_match(self):
+        context = determine_release_context(
+            {
+                "GITHUB_EVENT_NAME": "pull_request",
+                "GITHUB_REF": "refs/pull/123/merge",
+                "GITHUB_BASE_REF": "main",
+                "GITHUB_HEAD_REF": "release/2026.3.5",
+            }
+        )
+
+        self.assertEqual(
+            context,
+            ReleaseContext("2026.3.5", "Release pull request"),
+        )
+        # SCM can still infer from the preceding tag before the release tag exists.
+        self.assertEqual(validate_versions("2026.3.5", "2026.3.4.dev7", context), [])
+        self.assertEqual(len(validate_versions("2026.3.4", "2026.3.4.dev7", context)), 1)
+
+    def test_guarded_release_accepts_explicit_version(self):
+        context = determine_release_context(
+            {
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "GITHUB_REF": "refs/heads/main",
+            },
+            "2026.3.5",
+        )
+
+        self.assertEqual(context, ReleaseContext("2026.3.5", "Requested release"))
+        self.assertEqual(validate_versions("2026.3.5", "2026.3.6.dev1", context), [])
+
+    def test_rejects_malformed_or_conflicting_release_identity(self):
+        with self.assertRaisesRegex(ValueError, "Invalid release branch"):
+            determine_release_context(
+                {
+                    "GITHUB_EVENT_NAME": "pull_request",
+                    "GITHUB_BASE_REF": "main",
+                    "GITHUB_HEAD_REF": "release/not-a-version",
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "does not match tag"):
+            determine_release_context(
+                {"GITHUB_REF": "refs/tags/v2026.3.5"},
+                "2026.3.6",
+            )
+
+        with self.assertRaisesRegex(ValueError, "expected X.Y.Z"):
+            determine_release_context({}, "v2026.3.5")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/validate_version.py
+++ b/.github/scripts/validate_version.py
@@ -1,119 +1,206 @@
 #!/usr/bin/env python3
-"""
-Validate that the setuptools_scm version matches the CMake version for release tags.
+"""Validate release identities before mapget starts an expensive wheel build."""
 
-This script is used in the CI/CD pipeline to ensure version consistency
-between the CMake configuration and Git tags before deployment to PyPI.
+from __future__ import annotations
 
-The script compares:
-- Base version from CMakeLists.txt (e.g., "2025.3.0")
-- Base version from setuptools_scm (e.g., "2025.3.0" from tag or "2025.3.0.dev3" from commit)
-
-For release tags: versions must match exactly
-For dev builds: no validation, just ensure we got a reasonable version
-"""
-import re
-import sys
+import argparse
 import os
+import re
 import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
 
 
-def get_cmake_version():
-    """Extract MAPGET_VERSION from CMakeLists.txt"""
-    with open('CMakeLists.txt', 'r') as f:
-        content = f.read()
-    
-    match = re.search(r'set\(MAPGET_VERSION\s+([0-9.]+)\)', content)
+CMAKE_VERSION_PATTERN = re.compile(r"set\(MAPGET_VERSION\s+([0-9]+\.[0-9]+\.[0-9]+)\)")
+RELEASE_VERSION_PATTERN = re.compile(r"^v?([0-9]+\.[0-9]+\.[0-9]+)$")
+PLAIN_RELEASE_VERSION_PATTERN = re.compile(r"^([0-9]+\.[0-9]+\.[0-9]+)$")
+SCM_BASE_VERSION_PATTERN = re.compile(r"^([0-9]+\.[0-9]+\.[0-9]+)")
+
+
+@dataclass(frozen=True)
+class ReleaseContext:
+    """Describes which release identity, if any, the current CI event requires."""
+
+    expected_version: str | None
+    build_type: str
+    require_scm_match: bool = False
+
+
+def normalize_release_version(
+    value: str,
+    source: str,
+    *,
+    allow_leading_v: bool = True,
+) -> str:
+    """Return a strict three-component release version with controlled `v` handling."""
+    pattern = RELEASE_VERSION_PATTERN if allow_leading_v else PLAIN_RELEASE_VERSION_PATTERN
+    match = pattern.fullmatch(value)
     if not match:
-        raise ValueError("Could not find MAPGET_VERSION in CMakeLists.txt")
-    
+        expected_format = "X.Y.Z or vX.Y.Z" if allow_leading_v else "X.Y.Z"
+        raise ValueError(
+            f"Invalid {source} version {value!r}; expected {expected_format}."
+        )
     return match.group(1)
 
 
-def get_scm_version():
-    """Get version from setuptools_scm"""
+def get_cmake_version(path: Path = Path("CMakeLists.txt")) -> str:
+    """Extract the default `MAPGET_VERSION` from the root CMake project."""
+    match = CMAKE_VERSION_PATTERN.search(path.read_text(encoding="utf-8"))
+    if not match:
+        raise ValueError(f"Could not find MAPGET_VERSION in {path}.")
+    return match.group(1)
+
+
+def get_scm_version() -> str:
+    """Resolve the PEP 440 package version from the current Git checkout."""
     try:
         import setuptools_scm
-        # Use no-local-version to ensure PyPI compatibility
-        version = setuptools_scm.get_version(
-            local_scheme="no-local-version"
-        )
-        return version
+
+        return setuptools_scm.get_version(local_scheme="no-local-version")
     except ImportError:
-        # Fallback to command line
         result = subprocess.run(
-            [sys.executable, '-m', 'setuptools_scm'],
+            [sys.executable, "-m", "setuptools_scm"],
             capture_output=True,
-            text=True
+            text=True,
+            check=False,
         )
-        
         if result.returncode != 0:
-            raise ValueError(f"setuptools_scm failed: {result.stderr}")
-        
-        # Strip local version identifier if present
-        version = result.stdout.strip()
-        if '+' in version:
-            version = version.split('+')[0]
-        return version
+            raise ValueError(f"setuptools_scm failed: {result.stderr.strip()}")
+        return result.stdout.strip().split("+", 1)[0]
 
 
-def get_base_version(version):
-    """Extract base version (without dev/post parts)"""
-    # Remove everything after + (local version)
-    version = version.split('+')[0]
-    # Remove dev/post/rc parts
-    parts = version.split('.')
-    if len(parts) > 3:
-        # Check if last part is dev/post/rc
-        if parts[3].startswith('dev') or parts[3].startswith('post'):
-            parts = parts[:3]
-    return '.'.join(parts[:3])
+def get_base_version(version: str) -> str:
+    """Extract the X.Y.Z release base from a PEP 440 SCM version."""
+    match = SCM_BASE_VERSION_PATTERN.match(version)
+    if not match:
+        raise ValueError(f"Could not derive a release base from SCM version {version!r}.")
+    return match.group(1)
 
 
-def main():
-    cmake_version = get_cmake_version()
-    scm_version = get_scm_version()
+def determine_release_context(
+    environment: Mapping[str, str],
+    explicit_version: str | None = None,
+) -> ReleaseContext:
+    """Derive the expected version from a tag, release PR, or release-workflow input."""
+    expected = (
+        normalize_release_version(
+            explicit_version,
+            "requested release",
+            allow_leading_v=False,
+        )
+        if explicit_version
+        else None
+    )
+    build_type = "Requested release" if expected else "Development build"
+    require_scm_match = False
+
+    github_ref = environment.get("GITHUB_REF", "")
+    if github_ref.startswith("refs/tags/"):
+        tag_version = normalize_release_version(
+            github_ref.removeprefix("refs/tags/"),
+            "tag",
+        )
+        if expected and expected != tag_version:
+            raise ValueError(
+                f"Requested release {expected} does not match tag version {tag_version}."
+            )
+        expected = tag_version
+        build_type = "Tagged release"
+        require_scm_match = True
+    elif (
+        environment.get("GITHUB_EVENT_NAME") == "pull_request"
+        and environment.get("GITHUB_BASE_REF") == "main"
+        and environment.get("GITHUB_HEAD_REF", "").startswith("release/")
+    ):
+        branch_version = normalize_release_version(
+            environment["GITHUB_HEAD_REF"].removeprefix("release/"),
+            "release branch",
+        )
+        if expected and expected != branch_version:
+            raise ValueError(
+                f"Requested release {expected} does not match release branch {branch_version}."
+            )
+        expected = branch_version
+        build_type = "Release pull request"
+
+    return ReleaseContext(expected, build_type, require_scm_match)
+
+
+def validate_versions(
+    cmake_version: str,
+    scm_version: str,
+    context: ReleaseContext,
+) -> list[str]:
+    """Return all release-version contract violations for the supplied context."""
     scm_base_version = get_base_version(scm_version)
-    
+    errors: list[str] = []
+
+    if context.expected_version:
+        if cmake_version != context.expected_version:
+            errors.append(
+                f"CMake version {cmake_version} does not match "
+                f"{context.build_type.lower()} version {context.expected_version}."
+            )
+        if context.require_scm_match and scm_base_version != context.expected_version:
+            errors.append(
+                f"SCM base version {scm_base_version} does not match "
+                f"tag version {context.expected_version}."
+            )
+    elif scm_base_version.startswith("0."):
+        errors.append(
+            f"Invalid development SCM version {scm_version}; Git history may be unavailable."
+        )
+
+    return errors
+
+
+def main() -> int:
+    """Validate the current checkout and publish resolved values to GitHub Actions."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--expected-version",
+        help="Release version requested by the guarded release workflow.",
+    )
+    args = parser.parse_args()
+
+    try:
+        cmake_version = get_cmake_version()
+        scm_version = get_scm_version()
+        scm_base_version = get_base_version(scm_version)
+        context = determine_release_context(os.environ, args.expected_version)
+        errors = validate_versions(cmake_version, scm_version, context)
+    except ValueError as error:
+        print(f"ERROR: {error}")
+        return 1
+
     print(f"CMake version: {cmake_version}")
-    print(f"SetupTools SCM version: {scm_version}")
-    print(f"SetupTools SCM base version: {scm_base_version}")
-    
-    # Check if this is a tagged release
-    github_ref = os.environ.get('GITHUB_REF', '')
-    is_tag = github_ref.startswith('refs/tags/')
-    is_dev = '.dev' in scm_version
-    
-    print(f"\nBuild type: {'Tagged release' if is_tag else 'Development build'}")
-    print(f"GitHub ref: {github_ref}")
-    
-    # Only validate version match for tagged releases
-    if is_tag:
-        # For tagged releases, version must match exactly
-        if cmake_version != scm_base_version:
-            print(f"\nERROR: Version mismatch for tagged release!")
-            print(f"  CMake:    {cmake_version}")
-            print(f"  SCM base: {scm_base_version}")
-            print(f"  This is a tagged release - versions must match exactly")
-            sys.exit(1)
-    else:
-        # For dev builds, just ensure we got a reasonable version
-        if scm_base_version.startswith('0.'):
-            print(f"\nERROR: Invalid dev version detected!")
-            print(f"  SCM version: {scm_version}")
-            print(f"  This suggests git history is not available")
-            sys.exit(1)
-        print(f"\nDev build - skipping strict version validation")
-    
-    print("\nVersion validation passed!")
-    
-    # Output for GitHub Actions
-    if 'GITHUB_OUTPUT' in os.environ:
-        with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-            f.write(f"version={scm_version}\n")
-            f.write(f"base_version={scm_base_version}\n")
-            f.write(f"cmake_version={cmake_version}\n")
+    print(f"Setuptools SCM version: {scm_version}")
+    print(f"Setuptools SCM base version: {scm_base_version}")
+    print(f"Build type: {context.build_type}")
+    print(f"GitHub ref: {os.environ.get('GITHUB_REF', '')}")
+    if context.expected_version:
+        print(f"Expected release version: {context.expected_version}")
+
+    if errors:
+        print("\nERROR: Release version validation failed:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    if not context.expected_version:
+        print("Development build: strict release identity checks do not apply.")
+    print("Version validation passed.")
+
+    if output_path := os.environ.get("GITHUB_OUTPUT"):
+        with open(output_path, "a", encoding="utf-8") as output:
+            output.write(f"version={scm_version}\n")
+            output.write(f"base_version={scm_base_version}\n")
+            output.write(f"cmake_version={cmake_version}\n")
+
+    return 0
 
 
-if __name__ == '__main__':
-    main()
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci-deploy.yaml
+++ b/.github/workflows/ci-deploy.yaml
@@ -6,6 +6,10 @@ on:
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ '**' ]
+  # The guarded release workflow creates the tag with GITHUB_TOKEN and then
+  # dispatches this workflow explicitly because token-authored pushes do not
+  # trigger another workflow run.
+  workflow_dispatch:
 
 jobs:
   determine-version:
@@ -25,21 +29,21 @@ jobs:
       
       - name: Install setuptools_scm
         run: pip install setuptools_scm
-      
+
+      - name: Test version validation
+        run: python .github/scripts/test_validate_version.py
+
+      # Fail malformed tags and release branches before starting the platform
+      # matrix instead of discovering the mismatch in the final deploy job.
+      - name: Validate release version
+        id: release-version
+        run: python .github/scripts/validate_version.py
+
       - name: Get version
         id: version
+        env:
+          CMAKE_VERSION: ${{ steps.release-version.outputs.cmake_version }}
         run: |
-          CMAKE_VERSION=$(python - <<'PY'
-          import re
-          from pathlib import Path
-
-          match = re.search(r'set\(MAPGET_VERSION\s+([0-9.]+)\)', Path('CMakeLists.txt').read_text())
-          if not match:
-              raise SystemExit('Could not find MAPGET_VERSION in CMakeLists.txt')
-          print(match.group(1))
-          PY
-          )
-
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$GITHUB_BASE_REF" == "main" && "$GITHUB_HEAD_REF" == release/* ]]; then
             # Release PRs need installable intermediate wheels before the final
             # release tag exists. Use the planned CMake version as the base so
@@ -65,6 +69,9 @@ jobs:
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       SCCACHE_GHA_ENABLED: "true"
+      # Release correctness is more important than cache speed. The GitHub
+      # cache backend can reject sccache reads when its egress quota is busy.
+      USE_SCCACHE: ${{ !startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -74,6 +81,7 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git submodule update --init --recursive --depth=1
       - name: Run sccache-cache
+        if: env.USE_SCCACHE == 'true'
         uses: mozilla-actions/sccache-action@v0.0.9
       - name: Install libuuid
         run: |
@@ -83,9 +91,14 @@ jobs:
           python3 -m venv venv && . ./venv/bin/activate
           pip install -U setuptools wheel pip
           mkdir -p build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
+          SCCACHE_ARGS=()
+          if [[ "$USE_SCCACHE" == "true" ]]; then
+            SCCACHE_ARGS+=(
+              -DCMAKE_C_COMPILER_LAUNCHER=sccache
+              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+            )
+          fi
+          cmake .. -DCMAKE_BUILD_TYPE=Release "${SCCACHE_ARGS[@]}" \
             -DMAPGET_ENABLE_TESTING=True \
             -DMAPGET_BUILD_EXAMPLES=True \
             -DMAPGET_WITH_WHEEL=True \
@@ -172,6 +185,7 @@ jobs:
     needs: [determine-version]
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macos-14, windows-2022]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -181,11 +195,13 @@ jobs:
             python-version: "3.10"
     env:
       SCCACHE_GHA_ENABLED: "true"
+      USE_SCCACHE: ${{ !startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Run sccache-cache
+        if: env.USE_SCCACHE == 'true'
         uses: mozilla-actions/sccache-action@v0.0.9
       - uses: actions/setup-python@v5
         with:
@@ -198,12 +214,17 @@ jobs:
           python -m pip install delocate
           export MACOSX_DEPLOYMENT_TARGET=11.0  # ARM64 requires macOS 11.0+
           mkdir -p build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release \
+          SCCACHE_ARGS=()
+          if [[ "$USE_SCCACHE" == "true" ]]; then
+            SCCACHE_ARGS+=(
+              -DCMAKE_C_COMPILER_LAUNCHER=sccache
+              -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+            )
+          fi
+          cmake .. -DCMAKE_BUILD_TYPE=Release "${SCCACHE_ARGS[@]}" \
                 -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
                 -DPython3_ROOT_DIR="$pythonLocation" \
                 -DPython3_FIND_FRAMEWORK=LAST \
-                -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
                 -DMAPGET_ENABLE_TESTING=ON \
                 -DMAPGET_BUILD_EXAMPLES=ON \
                 -DMAPGET_WITH_WHEEL=True \
@@ -227,17 +248,24 @@ jobs:
           echo "cmake -DPython3_ROOT_DIR=$env:pythonLocation"
           mkdir build
           cd build
-          cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release `
-                "-DPython3_ROOT_DIR=$env:pythonLocation" `
-                -DPython3_FIND_REGISTRY=LAST `
-                -DCMAKE_C_COMPILER_LAUNCHER=sccache `
-                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
-                -DMAPGET_ENABLE_TESTING=YES `
-                -DMAPGET_BUILD_EXAMPLES=YES `
-                -DMAPGET_WITH_WHEEL=True `
-                -DMAPGET_WITH_SERVICE=True `
-                -DMAPGET_WITH_HTTPLIB=True `
-                -DMAPGET_VERSION="${{ needs.determine-version.outputs.version }}"
+          $cmakeArgs = @(
+            ".."
+            "-GNinja"
+            "-DCMAKE_BUILD_TYPE=Release"
+            "-DPython3_ROOT_DIR=$env:pythonLocation"
+            "-DPython3_FIND_REGISTRY=LAST"
+            "-DMAPGET_ENABLE_TESTING=YES"
+            "-DMAPGET_BUILD_EXAMPLES=YES"
+            "-DMAPGET_WITH_WHEEL=True"
+            "-DMAPGET_WITH_SERVICE=True"
+            "-DMAPGET_WITH_HTTPLIB=True"
+            "-DMAPGET_VERSION=${{ needs.determine-version.outputs.version }}"
+          )
+          if ($env:USE_SCCACHE -eq "true") {
+            $cmakeArgs += "-DCMAKE_C_COMPILER_LAUNCHER=sccache"
+            $cmakeArgs += "-DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+          }
+          cmake @cmakeArgs
           cmake --build . --config Release
       - name: Deploy
         uses: actions/upload-artifact@v4
@@ -255,7 +283,8 @@ jobs:
     if: |
       (github.event_name == 'push' && 
       (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))) ||
-      (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/'))
+      (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,163 @@
+name: Create Release
+run-name: Create mapget v${{ inputs.version }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the leading v (X.Y.Z)
+        required: true
+        type: string
+      title:
+        description: Optional GitHub release title
+        required: false
+        type: string
+      notes:
+        description: Optional GitHub release notes; generated notes are used when empty
+        required: false
+        type: string
+
+permissions:
+  actions: write
+  contents: write
+
+concurrency:
+  group: mapget-release
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_VERSION: ${{ inputs.version }}
+      RELEASE_TITLE: ${{ inputs.title }}
+      RELEASE_NOTES: ${{ inputs.notes }}
+    steps:
+      # Releases are always cut from the current main head, regardless of which
+      # ref the operator happened to select in the workflow UI.
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/heads/main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install version tooling
+        run: pip install setuptools_scm
+
+      - name: Test version validation
+        run: python .github/scripts/test_validate_version.py
+
+      - name: Validate requested release
+        run: |
+          python .github/scripts/validate_version.py \
+            --expected-version "$RELEASE_VERSION"
+
+      - name: Resolve release target
+        id: target
+        run: |
+          git fetch origin main --tags
+          TARGET_SHA=$(git rev-parse HEAD)
+          REMOTE_MAIN_SHA=$(git rev-parse origin/main)
+          if [[ "$TARGET_SHA" != "$REMOTE_MAIN_SHA" ]]; then
+            echo "Checked-out target $TARGET_SHA is not current origin/main $REMOTE_MAIN_SHA." >&2
+            exit 1
+          fi
+          echo "sha=$TARGET_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Require green main CI
+        env:
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          SUCCESSFUL_RUN=$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow ci-deploy.yaml \
+            --commit "$TARGET_SHA" \
+            --event push \
+            --limit 20 \
+            --json databaseId,status,conclusion,headBranch,url \
+            --jq '.[] | select(
+              .headBranch == "main" and
+              .status == "completed" and
+              .conclusion == "success"
+            ) | .url' | head -n 1)
+          if [[ -z "$SUCCESSFUL_RUN" ]]; then
+            echo "No successful main CI run exists for $TARGET_SHA." >&2
+            exit 1
+          fi
+          echo "Validated main CI: $SUCCESSFUL_RUN"
+
+      - name: Create tag and GitHub release
+        env:
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          TAG="v$RELEASE_VERSION"
+          REMOTE_TAG_SHA=$(git ls-remote --tags origin "refs/tags/$TAG" | awk '{print $1}')
+          if [[ -n "$REMOTE_TAG_SHA" && "$REMOTE_TAG_SHA" != "$TARGET_SHA" ]]; then
+            echo "$TAG already points to $REMOTE_TAG_SHA instead of $TARGET_SHA." >&2
+            exit 1
+          fi
+
+          if [[ -z "$REMOTE_TAG_SHA" ]]; then
+            git tag "$TAG" "$TARGET_SHA"
+            git push origin "refs/tags/$TAG"
+          else
+            echo "$TAG already points to the requested target; keeping it."
+          fi
+
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "GitHub release $TAG already exists; keeping it."
+            exit 0
+          fi
+
+          TITLE="$RELEASE_TITLE"
+          if [[ -z "$TITLE" ]]; then
+            TITLE="$TAG"
+          fi
+
+          if [[ -n "$RELEASE_NOTES" ]]; then
+            NOTES_FILE="$RUNNER_TEMP/mapget-release-notes.md"
+            printf '%s\n' "$RELEASE_NOTES" > "$NOTES_FILE"
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --title "$TITLE" \
+              --notes-file "$NOTES_FILE"
+          else
+            gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --title "$TITLE" \
+              --generate-notes
+          fi
+
+      - name: Start release wheel deployment
+        env:
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          TAG="v$RELEASE_VERSION"
+          ACTIVE_RUN=$(gh run list \
+            --repo "$GITHUB_REPOSITORY" \
+            --workflow ci-deploy.yaml \
+            --branch "$TAG" \
+            --limit 20 \
+            --json status,conclusion,headSha,url \
+            --jq ".[] | select(
+              .headSha == \"$TARGET_SHA\" and
+              (.status != \"completed\" or .conclusion == \"success\")
+            ) | .url" | head -n 1)
+          if [[ -n "$ACTIVE_RUN" ]]; then
+            echo "Release CI is already active or successful: $ACTIVE_RUN"
+            exit 0
+          fi
+
+          # Pushes made with GITHUB_TOKEN do not recursively start workflows,
+          # so dispatch the tag build explicitly.
+          gh workflow run ci-deploy.yaml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$TAG"
+          echo "Dispatched release CI for $TAG."

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install version tooling
-        run: pip install setuptools_scm
+        run: "pip install --only-binary=:all: setuptools-scm==10.2.1"
 
       - name: Test version validation
         run: python .github/scripts/test_validate_version.py

--- a/docs/mapget-dev-guide.md
+++ b/docs/mapget-dev-guide.md
@@ -398,23 +398,25 @@ The `mapget` Python package is deployed to PyPI through GitHub Actions with auto
 
 #### Manual Steps:
 
-1. **Update Version**: Before creating a release, update `MAPGET_VERSION` in `CMakeLists.txt` to the new version (e.g., `2025.3.1`)
-2. **Commit and Push**: Commit this change to the `main` branch with a clear message like "Bump version to 2025.3.1"
-3. **Create GitHub Release**:
-  - Go to the repository's "Releases" page on GitHub
-  - Click "Create a new release"
-  - Set the tag to `v2025.3.1` (matching the CMakeLists.txt version)
-  - Select "Create new tag on publish"
-  - Fill in release title and notes
-  - Publish the release
+1. **Update Version**: On `release/X.Y.Z`, update `MAPGET_VERSION` in
+   `CMakeLists.txt` to `X.Y.Z`. Release-PR CI rejects a branch/version mismatch.
+2. **Merge Green Release PR**: Merge the version change and release content to
+   `main`, then wait for the resulting `CI and Deploy` run to succeed.
+3. **Run `Create Release`**: Start the manual GitHub Actions workflow from
+   `main`, enter `X.Y.Z` without a leading `v`, and optionally provide a title
+   and notes. Do not create the tag through the GitHub Releases page.
+
+The guarded workflow verifies the CMake version, current `main` head, and its
+successful CI run before creating `vX.Y.Z` and the GitHub release. It then
+dispatches the wheel workflow explicitly for that tag.
 
 #### Automated Process:
 
-When the release is published, GitHub Actions will automatically:
+When the guarded release workflow succeeds, GitHub Actions will automatically:
 
 - Use `setuptools_scm` to determine the version from the git tag
 - Pass this version to CMake during the build process (overriding the default in CMakeLists.txt)
-- Validate that the git tag matches the CMakeLists.txt version (release will fail if they don't match)
+- Validate the release branch and tag before starting the platform build matrix
 - Build wheels for all supported platforms (Linux x86_64/aarch64, macOS Intel/ARM, Windows) and Python versions (3.10-3.14)
 - Upload the official release to PyPI
 


### PR DESCRIPTION
## Summary

The `v2026.3.5` release initially reached the deploy job with CMake reporting `2026.3.4` while `setuptools_scm` reported `2026.3.5`. All wheels had already been built by the time the mismatch was detected.

This change makes that failure mode impossible in the normal release path:

- validate the CMake, SCM, release-branch, and expected release versions before starting the build matrix
- add focused unit coverage for release-version validation
- add a guarded `Create Release` workflow which tags the already-green `main` commit and dispatches deployment explicitly
- make `CI and Deploy` manually dispatchable for controlled recovery
- disable `sccache` for release builds to avoid external cache outages blocking publication
- disable matrix fail-fast so one transient platform failure does not cancel all sibling artifacts
- document the release procedure and discourage creating tags from GitHub's release form

## Validation

- `python3 .github/scripts/test_validate_version.py -v`
- `python3 -m py_compile .github/scripts/validate_version.py .github/scripts/test_validate_version.py`
- focused tag, branch, and explicit-version validation contexts
- `git diff --check`
- YAML parsing with PyYAML
- `actionlint v1.7.12`
