### PR TITLE
Constrain PyPI development publishing

### DIFF
--- a/.github/workflows/ci-deploy.yaml
+++ b/.github/workflows/ci-deploy.yaml
@@ -281,8 +281,7 @@ jobs:
   deploy:
     needs: [determine-version, build-manylinux, build-manylinux-aarch64, build]
     if: |
-      (github.event_name == 'push' && 
-      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))) ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
       (github.event_name == 'pull_request' && github.base_ref == 'main' && startsWith(github.head_ref, 'release/')) ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
@@ -339,8 +338,6 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "Uploading release PR development version ${{ steps.version.outputs.version }} to PyPI..."
-          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "Uploading development snapshot version ${{ steps.version.outputs.version }} to PyPI..."
           else
             echo "Uploading release version ${{ steps.version.outputs.version }} to PyPI..."
           fi

--- a/docs/mapget-dev-guide.md
+++ b/docs/mapget-dev-guide.md
@@ -425,10 +425,16 @@ When the guarded release workflow succeeds, GitHub Actions will automatically:
 
 ### Development Snapshots
 
-Every push to the `main` branch automatically triggers a development release:
-- Version is determined by `setuptools_scm` (e.g., `2025.3.0.dev61` for the 61st commit after the last tag)
-- Development versions are uploaded to PyPI and can be installed with `pip install mapget --pre`
-- No manual intervention required - the version is automatically derived from git history
+Pull requests from `release/X.Y.Z` to `main` publish development previews:
+
+- The preview version uses the planned CMake version and a unique CI serial
+  (for example, `2026.3.5.dev31001`).
+- Development versions can be installed with `pip install mapget --pre`.
+- Ordinary `main` pushes run the complete wheel matrix but do not upload
+  another PyPI snapshot.
+- Superseded development previews should be deleted from PyPI after the final
+  release is available. Retaining every platform wheel from every preview will
+  eventually exhaust PyPI's per-project storage quota.
 
 ### Version Management
 


### PR DESCRIPTION
## Summary

The post-merge main deployment reached PyPI's 10 GB per-project quota while uploading `2026.3.6.dev6`. Public package metadata currently accounts for about 9.92 GiB: approximately 7.30 GiB is development previews and 2.54 GiB is final releases.

This stops unbounded duplicate publication while preserving the preview path requested for releases:

- publish development wheels only for `release/X.Y.Z` pull requests targeting `main`
- continue running the complete wheel matrix on ordinary `main` pushes, but skip PyPI upload
- continue publishing final `vX.Y.Z` tag builds
- document deletion of superseded previews as part of release retention

Old previews still need a one-time manual purge through PyPI's project management UI because PyPI does not expose release deletion through its package API.

## Validation

- YAML parsing with PyYAML
- `actionlint v1.7.12`
- `git diff --check`
