### PR TITLE
Release 2026.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(mapget LANGUAGES CXX C)
 # Allow version to be set from command line for CI/CD
 # For local development, use the default version
 if(NOT DEFINED MAPGET_VERSION)
-  set(MAPGET_VERSION 2026.4.0)
+  set(MAPGET_VERSION 2026.4.1)
 endif()
 
 set(CMAKE_CXX_STANDARD 20)

--- a/docs/mapget-api.md
+++ b/docs/mapget-api.md
@@ -342,6 +342,12 @@ attachment cache in the initial implementation.
 `/interactive` is a WebSocket control channel. `/interactive/payload` carries
 the binary frames so a client can apply explicit backpressure.
 
+Each session has soft frame and byte watermarks. Crossing a watermark pauses
+admission of new jobs originating only from that session; it never blocks a
+service worker or discards completed work. Already-running and coalesced jobs
+can therefore move the outbox temporarily above a watermark. Payload draining
+reopens admission once the queue is below both thresholds.
+
 An interactive message contains `requests`, optional envelope-level
 `filterId`, `generation`, `channels`, optional `bindings`, and optional
 `stringPoolOffsets`. The filter definition may be on the envelope and is

--- a/docs/mapget-dev-guide.md
+++ b/docs/mapget-dev-guide.md
@@ -123,6 +123,13 @@ complete result, and notifies every waiter.
 `priorityTileIds` promotes keys already in the request. It does not add
 coverage or change data semantics.
 
+Requests may share an atomic work-admission gate which is fixed before
+submission. A closed gate keeps that request's unscheduled keys queued while
+workers continue with other requests. It does not detach the request from a job
+selected for another live consumer, and backpressure does not suppress work
+which has already started. Opening a gate calls `Service::notifyWorkAvailable()`
+so sleeping workers reconsider the queued keys.
+
 One coalesced source tile may serve ordinary tile consumers and several filter
 requests. Those filters run sequentially on the worker that completed the tile,
 and each source-local evaluation scatters immutable contributions to every
@@ -290,7 +297,13 @@ request coordination mutex, so an evaluation whose outputs were all removed
 can stop at its next cooperative boundary. Any partial result is discarded
 before contribution commit.
 
-When a tile frame leaves the bounded queue, the session retains only its key
+The interactive outbox limits are soft admission watermarks, not result-drop
+limits. Crossing either watermark closes that session's backend work gate;
+workers never wait for `/interactive/payload`. Results from work already in
+flight or shared with another session are still queued, so the outbox may
+temporarily exceed a watermark. Draining below both limits reopens the gate.
+
+When a tile frame leaves the outbox, the session retains only its key
 and optional absolute semantic expiry from `timestamp + ttl`; it never retains
 a second payload copy. A later omission clears that handoff. An expired
 handoff no longer suppresses an ordinary repeated request, while a missing or

--- a/libs/http-service/src/tiles-ws-session.cpp
+++ b/libs/http-service/src/tiles-ws-session.cpp
@@ -95,8 +95,8 @@ std::string_view catalogStatusToString(DataSourceCatalogStatus status)
 constexpr int64_t DEFAULT_PULL_WAIT_MS = 25000;
 constexpr int64_t MAX_PULL_WAIT_MS = 30000;
 constexpr int64_t MAX_PULL_BATCH_BYTES = 64 * 1024 * 1024;
-constexpr size_t MAX_QUEUED_OUTGOING_FRAMES = 4096;
-constexpr size_t MAX_QUEUED_OUTGOING_BYTES = 256 * 1024 * 1024;
+constexpr size_t OUTGOING_FRAME_ADMISSION_WATERMARK = 4096;
+constexpr size_t OUTGOING_BYTE_ADMISSION_WATERMARK = 256 * 1024 * 1024;
 constexpr int64_t LOWEST_TILE_PRIORITY = std::numeric_limits<int64_t>::max();
 constexpr bool EMIT_LOAD_STATE_FRAMES = false;
 
@@ -784,6 +784,7 @@ public:
     void cancel(std::string reason)
     {
         cancelled_ = true;
+        workAdmissionOpen_->store(false, std::memory_order_release);
         std::vector<LayerTilesRequest::Ptr> requestsToAbort;
         std::vector<FeatureLayerFilterTilesRequest::Ptr> filterRequestsToAbort;
         std::vector<PullDispatch> pullDispatches;
@@ -805,7 +806,6 @@ public:
             stagedRequest_.reset();
             pendingReconciliation_.reset();
             collectAllPullWaitersLocked(PullFrameResult::Status::Closed, pullDispatches);
-            outgoingCapacityChanged_.notify_all();
         }
 
         // Abort in-flight requests (best-effort).
@@ -1206,6 +1206,7 @@ private:
             *parsedRequest.filterRequest,
             priorityTileIds);
         request->sourceId_ = parsedRequest.sourceId;
+        request->setWorkAdmissionGate(workAdmissionOpen_);
         request->exactRoots_ = parsedRequest.exactRoots;
         std::erase_if(
             request->exactRoots_,
@@ -1262,6 +1263,7 @@ private:
             tileIds,
             priorityTileIds);
         request->sourceId_ = parsedRequest.sourceId;
+        request->setWorkAdmissionGate(workAdmissionOpen_);
         request->featureIdsByTile_ = parsedRequest.featureIdsByTile;
         std::erase_if(
             request->featureIdsByTile_,
@@ -1351,7 +1353,7 @@ private:
         auto frame = std::move(outgoing_.front());
         outgoing_.pop_front();
         untrackQueuedFrameLocked(frame);
-        outgoingCapacityChanged_.notify_all();
+        refreshWorkAdmissionLocked();
         if (frame.stringPoolCommit) {
             committedStringPoolOffsets_[frame.stringPoolCommit->first] = frame.stringPoolCommit->second;
         }
@@ -1562,23 +1564,22 @@ private:
         return lhs.priorityRank < rhs.priorityRank;
     }
 
-    /** Return true when another tile layer may be serialized without unbounded queue growth. */
-    [[nodiscard]] bool hasOutgoingCapacityLocked() const
+    /** Return whether the outbox is below its soft backend-work admission watermark. */
+    [[nodiscard]] bool hasBackendWorkCapacityLocked() const
     {
-        // Always allow an empty queue to accept the next layer, even if that
-        // single layer is larger than the nominal byte cap.
-        return outgoing_.empty()
-            || (outgoing_.size() < MAX_QUEUED_OUTGOING_FRAMES
-                && queuedOutgoingBytes_ < MAX_QUEUED_OUTGOING_BYTES);
+        return outgoing_.size() < OUTGOING_FRAME_ADMISSION_WATERMARK &&
+            queuedOutgoingBytes_ < OUTGOING_BYTE_ADMISSION_WATERMARK;
     }
 
-    /** Block backend producer callbacks until `/interactive/payload` drains queued frames. */
-    [[nodiscard]] bool waitForOutgoingCapacityLocked(std::unique_lock<std::mutex>& lock)
+    /** Publish a changed admission state and wake workers when this session becomes writable. */
+    void refreshWorkAdmissionLocked()
     {
-        outgoingCapacityChanged_.wait(lock, [this] {
-            return cancelled_ || hasOutgoingCapacityLocked();
-        });
-        return !cancelled_;
+        auto const open = !cancelled_.load(std::memory_order_acquire) &&
+            hasBackendWorkCapacityLocked();
+        auto const wasOpen = workAdmissionOpen_->exchange(open, std::memory_order_release);
+        if (!wasOpen && open) {
+            service_.notifyWorkAvailable();
+        }
     }
 
     /** Drop queued tile data frames omitted from the latest pending snapshot. */
@@ -1609,7 +1610,7 @@ private:
         if (droppedFrames > 0) {
             gTilesWsMetrics.totalDroppedFrames.fetch_add(droppedFrames, std::memory_order_relaxed);
             gTilesWsMetrics.totalDroppedBytes.fetch_add(droppedBytes, std::memory_order_relaxed);
-            outgoingCapacityChanged_.notify_all();
+            refreshWorkAdmissionLocked();
         }
     }
 
@@ -1655,6 +1656,7 @@ private:
             }
         }
         outgoing_.insert(insertIt, std::move(frame));
+        refreshWorkAdmissionLocked();
         gTilesWsMetrics.totalQueuedFrames.fetch_add(1, std::memory_order_relaxed);
         gTilesWsMetrics.totalQueuedBytes.fetch_add(bytes, std::memory_order_relaxed);
     }
@@ -1677,7 +1679,7 @@ private:
 
         gTilesWsMetrics.totalDroppedFrames.fetch_add(droppedFrames, std::memory_order_relaxed);
         gTilesWsMetrics.totalDroppedBytes.fetch_add(droppedBytes, std::memory_order_relaxed);
-        outgoingCapacityChanged_.notify_all();
+        refreshWorkAdmissionLocked();
     }
 
     /** Internal cancel path used by destructor/connection tear-down (no status emission). */
@@ -1685,6 +1687,7 @@ private:
     {
         if (cancelled_.exchange(true))
             return;
+        workAdmissionOpen_->store(false, std::memory_order_release);
         std::vector<LayerTilesRequest::Ptr> requestsToAbort;
         std::vector<FeatureLayerFilterTilesRequest::Ptr> filterRequestsToAbort;
         std::vector<PullDispatch> pullDispatches;
@@ -1706,7 +1709,6 @@ private:
             stagedRequest_.reset();
             pendingReconciliation_.reset();
             collectAllPullWaitersLocked(PullFrameResult::Status::Closed, pullDispatches);
-            outgoingCapacityChanged_.notify_all();
         }
 
         abortRequests(std::move(requestsToAbort));
@@ -1758,7 +1760,7 @@ private:
             std::optional<std::pair<std::string, simfil::StringId>> stringPoolCommit;
             std::vector<PullDispatch> pullDispatches;
             {
-                std::unique_lock lock(mutex_);
+                std::lock_guard lock(mutex_);
                 auto filterKey = filterRequestKey(layer);
                 auto requestedTileKey = matchPendingTileKeyLocked(
                     layer->id(),
@@ -1787,16 +1789,6 @@ private:
                 {
                     return;
                 }
-                if (!waitForOutgoingCapacityLocked(lock)) {
-                    return;
-                }
-                // Capacity waits release the mutex; a newer snapshot may have
-                // pruned or reassigned this output in the meantime.
-                if (!pendingTileKeys_.contains(*requestedTileKey) || !ownerIsCurrent()) {
-                    gTilesWsMetrics.obsoleteOwnerCallbacks.fetch_add(1, std::memory_order_relaxed);
-                    return;
-                }
-
                 if (currentWriteBatch_) {
                     raise("TilesWsSession writer callback re-entered");
                 }
@@ -2119,7 +2111,7 @@ private:
     AuthHeaders authHeaders_;
 
     mutable std::mutex mutex_;
-    std::condition_variable outgoingCapacityChanged_;
+    std::shared_ptr<std::atomic_bool> workAdmissionOpen_ = std::make_shared<std::atomic_bool>(true);
     uint64_t nextPullWaiterId_ = 1;
     std::deque<uint64_t> pendingPullWaiterOrder_;
     std::unordered_map<uint64_t, PullWaiter> pendingPullWaiters_;

--- a/libs/service/include/mapget/service/service.h
+++ b/libs/service/include/mapget/service/service.h
@@ -186,6 +186,14 @@ public:
     /** Check whether the request is done or still running. */
     bool isDone() const;
 
+    /**
+     * Attach a shared gate controlling admission of new tile jobs.
+     *
+     * Set the gate before submitting the request. A false value pauses only
+     * jobs originating from this request; running or shared jobs still publish.
+     */
+    LayerTilesRequest& setWorkAdmissionGate(std::shared_ptr<std::atomic_bool const> gate);
+
     /** The map id for which this request is dedicated. */
     std::string mapId_;
 
@@ -252,6 +260,9 @@ protected:
     nlohmann::json toJson();
 
 private:
+    /** Return whether this request may originate another tile job. */
+    [[nodiscard]] bool admitsNewWork() const;
+
     /** Resolve tile IDs into concrete keys while preserving priority/order. */
     void prepareResolvedLayer(LayerType layerType);
 
@@ -265,6 +276,7 @@ private:
     std::function<void(TileFeatureLayer::Ptr)> onFeatureLayer_;
     std::function<void(TileSourceDataLayer::Ptr)> onSourceDataLayer_;
     std::function<void(MapTileKey const&, TileLayer::LoadState)> onLoadStateChanged_;
+    std::shared_ptr<std::atomic_bool const> workAdmissionGate_;
 
     // So the service can track which tile index from resolvedTileKeys_
     // is next in line to be processed.
@@ -331,6 +343,15 @@ public:
     /** Check whether the request has been cancelled by the owning transport. */
     [[nodiscard]] bool isCancelled() const;
 
+    /**
+     * Attach a shared gate controlling admission of new source-tile jobs.
+     *
+     * Set the gate before submitting the request. It is inherited by source
+     * and relation-target child requests; already running work still completes.
+     */
+    FeatureLayerFilterTilesRequest&
+    setWorkAdmissionGate(std::shared_ptr<std::atomic_bool const> gate);
+
     /** The source map id for this filter execution. */
     std::string mapId_;
 
@@ -388,6 +409,7 @@ private:
 
     std::function<void(TileSubsetLayer::Ptr)> onFilterResult_;
     std::function<void(nlohmann::json const&)> onStatus_;
+    std::shared_ptr<std::atomic_bool const> workAdmissionGate_;
     mutable std::mutex outputMembershipMutex_;
     std::set<TileId> liveOutputTileIds_;
     std::weak_ptr<detail::FilterRequestExecution> execution_;
@@ -555,6 +577,9 @@ public:
     void retainOutputs(
         FeatureLayerFilterTilesRequest::Ptr const& request,
         std::set<TileId> const& retainedTileIds);
+
+    /** Wake workers after an external request-admission gate may have opened. */
+    void notifyWorkAvailable();
 
     /** DataSourceInfo for all data sources which have been added to this Service. */
     std::vector<DataSourceInfo> info(std::optional<AuthHeaders> const& clientHeaders = {});

--- a/libs/service/src/service-filter.cpp
+++ b/libs/service/src/service-filter.cpp
@@ -1617,6 +1617,7 @@ void FilterRequestExecution::scheduleRelationTarget(MapTileKey const& targetKey)
         targetKey.layerId_,
         std::vector<TileId>{targetKey.tileId_});
     child->sourceId_ = request->sourceId_;
+    child->setWorkAdmissionGate(request->workAdmissionGate_);
     auto self = shared_from_this();
     child->onFeatureLayer([self, targetKey](TileFeatureLayer::Ptr layer)
                           { self->collectRelationTarget(targetKey, std::move(layer)); });
@@ -2375,6 +2376,13 @@ bool FeatureLayerFilterTilesRequest::isCancelled() const
     return cancelled_;
 }
 
+FeatureLayerFilterTilesRequest&
+FeatureLayerFilterTilesRequest::setWorkAdmissionGate(std::shared_ptr<std::atomic_bool const> gate)
+{
+    workAdmissionGate_ = std::move(gate);
+    return *this;
+}
+
 void FeatureLayerFilterTilesRequest::wait()
 {
     std::unique_lock doneLock(statusMutex_);
@@ -2615,6 +2623,7 @@ bool detail::FilterRequestExecution::start(
         *tileIdsToProcess,
         prioritySourceTileIds);
     childRequest->sourceId_ = request->sourceId_;
+    childRequest->setWorkAdmissionGate(request->workAdmissionGate_);
     {
         std::lock_guard lock(request->childRequestsMutex_);
         request->childRequests_.push_back(childRequest);

--- a/libs/service/src/service-scheduler.cpp
+++ b/libs/service/src/service-scheduler.cpp
@@ -105,6 +105,15 @@ void ServiceScheduler::enqueueRequest(LayerTilesRequest::Ptr request)
     jobsAvailable_.notify_all();
 }
 
+void ServiceScheduler::notifyWorkAvailable()
+{
+    // Synchronize with the condition-variable wait boundary. Without taking
+    // this mutex, an external atomic gate could open after a worker checks it
+    // but before the worker actually sleeps, losing the notification.
+    std::lock_guard lock(mutex_);
+    jobsAvailable_.notify_all();
+}
+
 void ServiceScheduler::abortRequest(LayerTilesRequest::Ptr const& request)
 {
     if (!request || request->isDone()) {
@@ -422,7 +431,7 @@ std::optional<ServiceScheduler::Candidate>
 ServiceScheduler::nextCandidateLocked(SourceConcurrency const& source) const
 {
     for (auto request = requests_.begin(); request != requests_.end(); ++request) {
-        if (!requestMatchesSourceLocked(*request, source)) {
+        if (!requestMatchesSourceLocked(*request, source) || !(*request)->admitsNewWork()) {
             continue;
         }
         auto pendingIndex = nextPendingTileKeyLocked(**request);

--- a/libs/service/src/service-scheduler.h
+++ b/libs/service/src/service-scheduler.h
@@ -90,6 +90,9 @@ public:
     /** Enqueue a validated tile request. */
     void enqueueRequest(LayerTilesRequest::Ptr request);
 
+    /** Wake workers so externally gated requests are reconsidered. */
+    void notifyWorkAvailable();
+
     /** Abort and detach one tile request from queued and in-flight work. */
     void abortRequest(LayerTilesRequest::Ptr const& request);
 

--- a/libs/service/src/service-tiles.cpp
+++ b/libs/service/src/service-tiles.cpp
@@ -617,6 +617,18 @@ bool LayerTilesRequest::isDone() const
     return status_ != RequestStatus::Open;
 }
 
+LayerTilesRequest&
+LayerTilesRequest::setWorkAdmissionGate(std::shared_ptr<std::atomic_bool const> gate)
+{
+    workAdmissionGate_ = std::move(gate);
+    return *this;
+}
+
+bool LayerTilesRequest::admitsNewWork() const
+{
+    return !workAdmissionGate_ || workAdmissionGate_->load(std::memory_order_acquire);
+}
+
 bool Service::Impl::requestTiles(
     std::vector<LayerTilesRequest::Ptr> const& requests,
     std::optional<AuthHeaders> const& clientHeaders)

--- a/libs/service/src/service.cpp
+++ b/libs/service/src/service.cpp
@@ -194,6 +194,11 @@ void Service::retainOutputs(
     }
 }
 
+void Service::notifyWorkAvailable()
+{
+    impl_->scheduler_.notifyWorkAvailable();
+}
+
 std::vector<DataSourceInfo> Service::info(std::optional<AuthHeaders> const& clientHeaders)
 {
     return impl_->getDataSourceInfos(clientHeaders);

--- a/test/unit/test-filter-service.cpp
+++ b/test/unit/test-filter-service.cpp
@@ -789,6 +789,37 @@ TEST_CASE(
 }
 
 TEST_CASE(
+    "Filter source requests inherit their work admission gate",
+    "[feature-layer-filter][Service][backpressure]")
+{
+    auto service = Service(std::make_shared<MemCache>(32), false, std::chrono::milliseconds{0}, 1);
+    auto dataSource = std::make_shared<FilterDataSource>();
+    service.add(dataSource);
+    auto admissionOpen = std::make_shared<std::atomic_bool>(false);
+    auto request = std::make_shared<FeatureLayerFilterTilesRequest>(
+        "FilterMap",
+        "Road",
+        std::vector<TileId>{firstTile()},
+        filterDefinition());
+    request->setWorkAdmissionGate(admissionOpen);
+
+    REQUIRE(service.request(request));
+    auto liveRequest =
+        std::make_shared<LayerTilesRequest>("FilterMap", "Road", std::vector<TileId>{secondTile()});
+    REQUIRE(service.request(std::vector<LayerTilesRequest::Ptr>{liveRequest}));
+    liveRequest->wait();
+    REQUIRE(liveRequest->getStatus() == RequestStatus::Success);
+    REQUIRE(dataSource->requestedTiles() == std::vector<TileId>{secondTile()});
+
+    admissionOpen->store(true);
+    service.notifyWorkAvailable();
+    request->wait();
+
+    REQUIRE(request->getStatus() == RequestStatus::Success);
+    REQUIRE(dataSource->requestedTiles() == std::vector<TileId>{secondTile(), firstTile()});
+}
+
+TEST_CASE(
     "Filter evaluation does not wait for earlier source completion",
     "[feature-layer-filter][Service][concurrency]")
 {

--- a/test/unit/test-service-ttl.cpp
+++ b/test/unit/test-service-ttl.cpp
@@ -323,6 +323,69 @@ TEST_CASE("Service preserves per-datasource permits below the global cap", "[Ser
     REQUIRE((*constrainedRow)["parallel-limit"] == 1);
 }
 
+TEST_CASE("Service skips requests while their work admission is closed", "[Service][backpressure]")
+{
+    auto blockedProbe = std::make_shared<GlobalConcurrencyProbe>();
+    auto liveProbe = std::make_shared<GlobalConcurrencyProbe>();
+    Service service(std::make_shared<MemCache>(32), false, 0ms, 1);
+    service.add(
+        std::make_shared<ConcurrencyTestDataSource>("BlockedMap", "BlockedPool", blockedProbe));
+    service.add(std::make_shared<ConcurrencyTestDataSource>("LiveMap", "LivePool", liveProbe));
+
+    auto admissionOpen = std::make_shared<std::atomic_bool>(false);
+    auto blocked = std::make_shared<LayerTilesRequest>(
+        "BlockedMap",
+        "Features",
+        std::vector<TileId>{TileId::fromTileXY(0, 0, 3)});
+    blocked->setWorkAdmissionGate(admissionOpen);
+    auto live = std::make_shared<
+        LayerTilesRequest>("LiveMap", "Features", std::vector<TileId>{TileId::fromTileXY(0, 0, 3)});
+
+    REQUIRE(service.request({blocked, live}));
+    auto const liveStarted = liveProbe->waitForEntries(1, 2s);
+    liveProbe->release();
+    live->wait();
+    auto const blockedStayedQueued = !blockedProbe->waitForEntries(1, 100ms);
+
+    admissionOpen->store(true);
+    service.notifyWorkAvailable();
+    auto const blockedStarted = blockedProbe->waitForEntries(1, 2s);
+    blockedProbe->release();
+    blocked->wait();
+
+    REQUIRE(liveStarted);
+    REQUIRE(blockedStayedQueued);
+    REQUIRE(blockedStarted);
+    REQUIRE(live->getStatus() == RequestStatus::Success);
+    REQUIRE(blocked->getStatus() == RequestStatus::Success);
+}
+
+TEST_CASE("Shared work still completes requests with closed admission", "[Service][backpressure]")
+{
+    Service service(std::make_shared<MemCache>(32), false, 0ms, 1);
+    auto source = std::make_shared<TestTtlDataSource>();
+    service.add(source);
+    auto const tileId = TileId::fromValue(kTtlTileIdValue);
+
+    auto sharedResultCount = std::atomic_size_t{0};
+    auto blocked =
+        std::make_shared<LayerTilesRequest>("Tropico", "WayLayer", std::vector<TileId>{tileId});
+    blocked->setWorkAdmissionGate(std::make_shared<std::atomic_bool>(false));
+    blocked->onFeatureLayer([&](TileFeatureLayer::Ptr) { ++sharedResultCount; });
+    auto live =
+        std::make_shared<LayerTilesRequest>("Tropico", "WayLayer", std::vector<TileId>{tileId});
+    live->onFeatureLayer([&](TileFeatureLayer::Ptr) { ++sharedResultCount; });
+
+    REQUIRE(service.request({blocked, live}));
+    blocked->wait();
+    live->wait();
+
+    REQUIRE(blocked->getStatus() == RequestStatus::Success);
+    REQUIRE(live->getStatus() == RequestStatus::Success);
+    REQUIRE(sharedResultCount == 2);
+    REQUIRE(source->fillCount() == 1);
+}
+
 TEST_CASE("Service rejects an empty homogeneous worker pool", "[Service][concurrency]")
 {
     REQUIRE_THROWS_AS(Service(std::make_shared<MemCache>(1), false, 0ms, 0), std::runtime_error);


### PR DESCRIPTION
## mapget 2026.4.1

Patch release preventing slow interactive clients from blocking service workers while retaining bounded, per-session work admission.

### Improved

- Apply cooperative backpressure to interactive tile sessions without blocking shared backend work.
- Preserve already-running and coalesced work while pausing only new jobs owned by a saturated session.
- Document the interactive outbox watermarks and work-admission contract.

### TODOs

- [x] Merge after CI succeeds.
- [x] Tag and publish v2026.4.1 through the guarded release workflow.
